### PR TITLE
Deprecate the JS part of commons validator

### DIFF
--- a/src/javascript/org/apache/commons/validator/javascript/validateByte.js
+++ b/src/javascript/org/apache/commons/validator/javascript/validateByte.js
@@ -19,6 +19,9 @@
     * Check to see if fields are a valid byte.
     * Fields are not checked if they are disabled.
     * @param form The form validation is taking place on.
+    * @deprecated The JS part of commons validation is deprecated
+    *   Please consider using http://parsleyjs.org/ or another 
+    *   validation library.
     */
     function validateByte(form) {
         var bValid = true;

--- a/src/javascript/org/apache/commons/validator/javascript/validateCreditCard.js
+++ b/src/javascript/org/apache/commons/validator/javascript/validateCreditCard.js
@@ -19,6 +19,9 @@
     * Check to see if fields are a valid creditcard number based on Luhn checksum.
     * Fields are not checked if they are disabled.
     * @param form The form validation is taking place on.
+    * @deprecated The JS part of commons validation is deprecated
+    *   Please consider using http://parsleyjs.org/ or another 
+    *   validation library.
     */
     function validateCreditCard(form) {
         var bValid = true;
@@ -58,6 +61,10 @@
      * Checks whether a given credit card number has a valid Luhn checksum.
      * This allows you to spot most randomly made-up or garbled credit card numbers immediately.
      * Reference: http://www.speech.cs.cmu.edu/~sburke/pub/luhn_lib.html
+     *
+     * @deprecated The JS part of commons validation is deprecated
+     *   Please consider using http://parsleyjs.org/ or another 
+     *   validation library.
      */
     function jcv_luhnCheck(cardNumber) {
         if (jcv_isLuhnNum(cardNumber)) {
@@ -78,6 +85,11 @@
         return false;
     }
 
+    /**
+     * @deprecated The JS part of commons validation is deprecated
+     *   Please consider using http://parsleyjs.org/ or another 
+     *   validation library.
+     */
     function jcv_isLuhnNum(argvalue) {
         argvalue = argvalue.toString();
         if (argvalue.length == 0) {

--- a/src/javascript/org/apache/commons/validator/javascript/validateDate.js
+++ b/src/javascript/org/apache/commons/validator/javascript/validateDate.js
@@ -19,6 +19,9 @@
     * Check to see if fields are a valid date.
     * Fields are not checked if they are disabled.
     * @param form The form validation is taking place on.
+    * @deprecated The JS part of commons validation is deprecated
+    *   Please consider using http://parsleyjs.org/ or another 
+    *   validation library.
     */
     function validateDate(form) {
        var bValid = true;
@@ -183,6 +186,11 @@
        return bValid;
     }
     
+    /**
+     * @deprecated The JS part of commons validation is deprecated
+     *   Please consider using http://parsleyjs.org/ or another 
+     *   validation library.
+     */
     function jcv_isValidDate(day, month, year) {
 	    if (month < 1 || month > 12) {
             return false;

--- a/src/javascript/org/apache/commons/validator/javascript/validateEmail.js
+++ b/src/javascript/org/apache/commons/validator/javascript/validateEmail.js
@@ -19,6 +19,9 @@
     * Check to see if fields are a valid email address.
     * Fields are not checked if they are disabled.
     * @param form The form validation is taking place on.
+    * @deprecated The JS part of commons validation is deprecated
+    *   Please consider using http://parsleyjs.org/ or another 
+    *   validation library.
     */
     function validateEmail(form) {
         var bValid = true;
@@ -58,6 +61,9 @@
     /**
      * Reference: Sandeep V. Tamhankar (stamhankar@hotmail.com),
      * http://javascript.internet.com
+     * @deprecated The JS part of commons validation is deprecated
+     *   Please consider using http://parsleyjs.org/ or another 
+     *   validation library.
      */
     function jcv_checkEmail(emailStr) {
         if (emailStr.length == 0) {

--- a/src/javascript/org/apache/commons/validator/javascript/validateFloat.js
+++ b/src/javascript/org/apache/commons/validator/javascript/validateFloat.js
@@ -19,6 +19,9 @@
     * Check to see if fields are a valid float.
     * Fields are not checked if they are disabled.
     * @param form The form validation is taking place on.
+    * @deprecated The JS part of commons validation is deprecated
+    *   Please consider using http://parsleyjs.org/ or another 
+    *   validation library.
     */
     function validateFloat(form) {
         var bValid = true;

--- a/src/javascript/org/apache/commons/validator/javascript/validateFloatRange.js
+++ b/src/javascript/org/apache/commons/validator/javascript/validateFloatRange.js
@@ -19,6 +19,9 @@
     * Check to see if fields are in a valid float range.
     * Fields are not checked if they are disabled.
     * @param form The form validation is taking place on.
+    * @deprecated The JS part of commons validation is deprecated
+    *   Please consider using http://parsleyjs.org/ or another 
+    *   validation library.
     */
     function validateFloatRange(form) {
         var isValid = true;

--- a/src/javascript/org/apache/commons/validator/javascript/validateIntRange.js
+++ b/src/javascript/org/apache/commons/validator/javascript/validateIntRange.js
@@ -19,6 +19,9 @@
     * Check to see if fields is in a valid integer range.
     * Fields are not checked if they are disabled.
     * @param form The form validation is taking place on.
+    * @deprecated The JS part of commons validation is deprecated
+    *   Please consider using http://parsleyjs.org/ or another 
+    *   validation library.
     */
     function validateIntRange(form) {
         var isValid = true;

--- a/src/javascript/org/apache/commons/validator/javascript/validateInteger.js
+++ b/src/javascript/org/apache/commons/validator/javascript/validateInteger.js
@@ -19,6 +19,9 @@
     * Check to see if fields are a valid integer.
     * Fields are not checked if they are disabled.
     * @param form The form validation is taking place on.
+    * @deprecated The JS part of commons validation is deprecated
+    *   Please consider using http://parsleyjs.org/ or another 
+    *   validation library.
     */
     function validateInteger(form) {
         var bValid = true;

--- a/src/javascript/org/apache/commons/validator/javascript/validateMask.js
+++ b/src/javascript/org/apache/commons/validator/javascript/validateMask.js
@@ -19,6 +19,9 @@
     * Check to see if fields are a valid using a regular expression.
     * Fields are not checked if they are disabled.
     * @param form The form validation is taking place on.
+    * @deprecated The JS part of commons validation is deprecated
+    *   Please consider using http://parsleyjs.org/ or another 
+    *   validation library.
     */
     function validateMask(form) {
         var isValid = true;
@@ -58,6 +61,11 @@
         return isValid;
     }
 
+    /**
+     * @deprecated The JS part of commons validation is deprecated
+     *   Please consider using http://parsleyjs.org/ or another 
+     *   validation library.
+     */
     function jcv_matchPattern(value, mask) {
        return mask.exec(value);
     }

--- a/src/javascript/org/apache/commons/validator/javascript/validateMaxLength.js
+++ b/src/javascript/org/apache/commons/validator/javascript/validateMaxLength.js
@@ -23,6 +23,9 @@
     *  login page gives unnecessary information away to hackers. While it only slightly
     *  weakens security, we suggest using it only when modifying a password.
     * @param form The form validation is taking place on.
+    * @deprecated The JS part of commons validation is deprecated
+    *   Please consider using http://parsleyjs.org/ or another 
+    *   validation library.
     */
     function validateMaxLength(form) {
         var isValid = true;

--- a/src/javascript/org/apache/commons/validator/javascript/validateMinLength.js
+++ b/src/javascript/org/apache/commons/validator/javascript/validateMinLength.js
@@ -23,6 +23,9 @@
     *  login page gives unnecessary information away to hackers. While it only slightly
     *  weakens security, we suggest using it only when modifying a password.
     * @param form The form validation is taking place on.
+    * @deprecated The JS part of commons validation is deprecated
+    *   Please consider using http://parsleyjs.org/ or another 
+    *   validation library.
     */
     function validateMinLength(form) {
         var isValid = true;

--- a/src/javascript/org/apache/commons/validator/javascript/validateRequired.js
+++ b/src/javascript/org/apache/commons/validator/javascript/validateRequired.js
@@ -20,8 +20,10 @@
     * Fields are not checked if they are disabled.
     *
     * @param form The form validation is taking place on.
+    * @deprecated The JS part of commons validation is deprecated
+    *   Please consider using http://parsleyjs.org/ or another 
+    *   validation library.
     */
-
     function validateRequired(form) {
         var isValid = true;
         var focusField = null;

--- a/src/javascript/org/apache/commons/validator/javascript/validateShort.js
+++ b/src/javascript/org/apache/commons/validator/javascript/validateShort.js
@@ -20,6 +20,9 @@
     * Fields are not checked if they are disabled.
     *
     * @param form The form validation is taking place on.
+    * @deprecated The JS part of commons validation is deprecated
+    *   Please consider using http://parsleyjs.org/ or another 
+    *   validation library.
     */
     function validateShort(form) {
         var bValid = true;

--- a/src/javascript/org/apache/commons/validator/javascript/validateUtilities.js
+++ b/src/javascript/org/apache/commons/validator/javascript/validateUtilities.js
@@ -23,6 +23,9 @@
   /**
    * Retreive the name of the form
    * @param form The form validation is taking place on.
+   * @deprecated The JS part of commons validation is deprecated
+   *   Please consider using http://parsleyjs.org/ or another 
+   *   validation library.
    */
   function jcv_retrieveFormName(form) {
 
@@ -62,6 +65,9 @@
    * Handle error messages.
    * @param messages Array of error messages.
    * @param focusField Field to set focus on.
+   * @deprecated The JS part of commons validation is deprecated
+   *   Please consider using http://parsleyjs.org/ or another 
+   *   validation library.
    */
   function jcv_handleErrors(messages, focusField) {
       if (focusField && focusField != null) {
@@ -90,6 +96,9 @@
    * all objects, including Arrays).
    * @param name The element name.
    * @param value The element value.
+   * @deprecated The JS part of commons validation is deprecated
+   *   Please consider using http://parsleyjs.org/ or another 
+   *   validation library.
    */
   function jcv_verifyArrayElement(name, element) {
       if (element && element.length && element.length == 3) {
@@ -102,6 +111,9 @@
   /**
    * Checks whether the field is present on the form.
    * @param field The form field.
+   * @deprecated The JS part of commons validation is deprecated
+   *   Please consider using http://parsleyjs.org/ or another 
+   *   validation library.
    */
   function jcv_isFieldPresent(field) {
       var fieldPresent = true;
@@ -118,6 +130,9 @@
   /**
    * Check a value only contains valid numeric digits
    * @param argvalue The value to check.
+   * @deprecated The JS part of commons validation is deprecated
+   *   Please consider using http://parsleyjs.org/ or another 
+   *   validation library.
    */
   function jcv_isAllDigits(argvalue) {
       argvalue = argvalue.toString();
@@ -142,6 +157,9 @@
   /**
    * Check a value only contains valid decimal digits
    * @param argvalue The value to check.
+   * @deprecated The JS part of commons validation is deprecated
+   *   Please consider using http://parsleyjs.org/ or another 
+   *   validation library.
    */
   function jcv_isDecimalDigits(argvalue) {
       argvalue = argvalue.toString();
@@ -158,7 +176,21 @@
       return true;
   }
     
-    // Trim whitespace from left and right sides of s.
-    function trim(s) {
-        return s.replace( /^\s*/, "" ).replace( /\s*$/, "" );
-    }
+  /**
+   * Trim whitespace from left and right sides of s.
+   * @deprecated The JS part of commons validation is deprecated
+   *   Please consider using http://parsleyjs.org/ or another 
+   *   validation library.
+   */
+  function trim(s) {
+      return s.replace( /^\s*/, "" ).replace( /\s*$/, "" );
+  }
+
+
+  // Log a message to the console which states that this validation library 
+  // is deprecated.
+  if (typeof(console) !== 'undefined' && typeof(console.warn) === 'function') {
+      console.warn('The JS part of commons validation is deprecated. ' +
+          'Please consider using http://parsleyjs.org/ or another ' +
+          'validation library.');
+  }


### PR DESCRIPTION
The JS parts of commons-validator haven't been updated in a while and don't necessarily follow common security best practices (almost every function uses `eval`). At the same time there are quite a few issues that are several years old and haven't been worked upon [1].

For this reason I propose to deprecate (and later remove) the JS component of commons-validator using JavaDoc / JSDoc mechanisms and with a warning on the browser's console. All deprecation messages refer to an alternative that is commonly used and actively maintained to give the users some guidance.

[1] https://issues.apache.org/jira/browse/VALIDATOR-322?jql=project%20%3D%20VALIDATOR%20AND%20component%20%3D%20JavaScript%20AND%20status%20%3D%20Open%20ORDER%20BY%20priority%20DESC
