### PR TITLE
Field does not synchronize iteration on synchronized list

### DIFF
--- a/src/main/java/org/apache/commons/validator/Field.java
+++ b/src/main/java/org/apache/commons/validator/Field.java
@@ -903,22 +903,24 @@ public class Field implements Cloneable, Serializable {
 
         for (int fieldNumber = 0; fieldNumber < numberOfFieldsToValidate; fieldNumber++) {
 
-            Iterator<String> dependencies = this.dependencyList.iterator();
             ValidatorResults results = new ValidatorResults();
-            while (dependencies.hasNext()) {
-                String depend = dependencies.next();
+            synchronized(dependencyList) {
+                Iterator<String> dependencies = this.dependencyList.iterator();
+                while (dependencies.hasNext()) {
+                    String depend = dependencies.next();
 
-                ValidatorAction action = actions.get(depend);
-                if (action == null) {
-                    this.handleMissingAction(depend);
-                }
+                    ValidatorAction action = actions.get(depend);
+                    if (action == null) {
+                        this.handleMissingAction(depend);
+                    }
 
-                boolean good =
-                    validateForRule(action, results, actions, params, fieldNumber);
+                    boolean good =
+                        validateForRule(action, results, actions, params, fieldNumber);
 
-                if (!good) {
-                    allResults.merge(results);
-                    return allResults;
+                    if (!good) {
+                        allResults.merge(results);
+                        return allResults;
+                    }
                 }
             }
             allResults.merge(results);


### PR DESCRIPTION
In Field.java:908, the synchronized list `dependencyList` is iterated in an unsynchronized manner, 
but according to the [Oracle Java 7 API specification](http://docs.oracle.com/javase/7/docs/api/java/util/Collections.html#synchronizedList%28java.util.List%29),
this is not thread-safe and can lead to non-deterministic behavior. 
This pull request adds a fix by synchronizing the iteration.
