### PR TITLE
VALIDATOR-453 support unicode characters in paths

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/UrlValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/UrlValidator.java
@@ -165,7 +165,7 @@ public class UrlValidator implements Serializable {
      */
     private static final int PARSE_AUTHORITY_EXTRA = 4;
 
-    private static final String PATH_REGEX = "^(/[-\\w:@&?=+,.!/~*'%$_;\\(\\)]*)?$";
+    private static final String PATH_REGEX = "^(/[-\\w\\pL:@&?=+,.!/~*'%$_;\\(\\)]*)?$";
     private static final Pattern PATH_PATTERN = Pattern.compile(PATH_REGEX);
 
     private static final String QUERY_REGEX = "^(\\S*)$";

--- a/src/test/java/org/apache/commons/validator/routines/UrlValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/UrlValidatorTest.java
@@ -498,6 +498,12 @@ protected void setUp() {
        assertTrue(validator.isValid("http://example.com/serach?address=Main+Avenue"));
    }
 
+    public void testValidator453() {
+        final String[] schemes = {"http", "https"};
+        final UrlValidator validator = new UrlValidator(schemes);
+        assertTrue(validator.isValid("https://www.linkedin.com/in/ølæ-nordmånn/"));
+    }
+
    //-------------------- Test data for creating a composite URL
    /**
     * The data given below approximates the 4 parts of a URL


### PR DESCRIPTION
LinkedIn allows unicode characters such as æøå in their urls, which fails due to the PATH_REGEX using only `\\w`. Change by adding `\\pL`