### PR TITLE
fix travis-ci scripts.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,19 +14,20 @@
 # limitations under the License.
 
 language: java
+dist: trusty
 cache:
   directories:
     - $HOME/.m2
-
 matrix:
   include:
-    - os: linux-AMD64
-      jdk: openjdk8
+    - jdk: openjdk7
+    - jdk: openjdk8
+    - jdk: openjdk11
     - os: linux-ppc64le
       jdk: openjdk8
-
+  allow_failures:
+    - jdk: openjdk11
 script:
   - mvn
-
 after_success:
   - mvn clean cobertura:cobertura coveralls:report

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,7 @@ matrix:
     - jdk: openjdk11
     - os: linux-ppc64le
       jdk: openjdk8
-  allow_failures:
-    - jdk: openjdk11
 script:
   - mvn clean test
-
 after_success:
   - mvn clean cobertura:cobertura coveralls:report

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,19 +14,16 @@
 # limitations under the License.
 
 language: java
-jdk:
-  - openjdk8
-  - openjdk11
-  - openjdk13
-  - openjdk14
-  - openjdk-ea
+cache:
+  directories:
+    - $HOME/.m2
 
 matrix:
   include:
+    - os: linux-AMD64
+      jdk: openjdk8
     - os: linux-ppc64le
       jdk: openjdk8
-  allow_failures:
-    - jdk: openjdk-ea
 
 script:
   - mvn


### PR DESCRIPTION
add cache m2 to travis-ci.
delete openjdk13,openjdk14,openjdk-ea because java 1.6 cannot be used on such jdks.

```
[ERROR] Failures:
[ERROR]   CalendarValidatorTest.testDateTimeStyle:197 validate(A) default
[ERROR]   CalendarValidatorTest.testFormat:215 default expected:<31/12/[]05> but was:<31/12/[20]05>
[ERROR]   CurrencyValidatorTest.testIntegerValid:142 US negative expected:<-1234.00> but was:<null>
[ERROR]   CurrencyValidatorTest.testInvalid:121 US wrong negative
[ERROR]   CurrencyValidatorTest.testValid:93 US negative expected:<-1234.56> but was:<null>
[ERROR]   DateValidatorTest.testDateValidatorMethods:69 validate(A) both expected:<Sat Dec 31 00:00:00 CST 2005> but was:<null>
[ERROR]   TimeValidatorTest.testTimeZone:224 pattern result
[ERROR] Errors:
[ERROR]   CalendarValidatorTest.testCalendarValidatorMethods:70 NullPointer
```

_I see no plans about fixing them in near days, so I think we'd better disable it until a fix comes up._

nope, that test seems already been fixed.