### PR TITLE
JUnit assertThrows

### DIFF
--- a/src/test/java/org/apache/commons/validator/routines/DomainValidatorStartupTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/DomainValidatorStartupTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.commons.validator.routines;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.*;
 
 import java.util.ArrayList;
@@ -23,6 +26,7 @@ import java.util.List;
 
 import org.apache.commons.validator.routines.DomainValidator.ArrayType;
 import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
 import org.junit.runner.RunWith;
 
 import org.bitstrings.test.junit.runner.ClassLoaderPerTestRunner;
@@ -34,24 +38,52 @@ import org.bitstrings.test.junit.runner.ClassLoaderPerTestRunner;
 @RunWith( ClassLoaderPerTestRunner.class )
 public class DomainValidatorStartupTest {
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testUpdateBaseArrayCC() {
-        DomainValidator.updateTLDOverride(ArrayType.COUNTRY_CODE_RO, new String[]{"com"});
+        // FIXME Simplification once upgraded to Java 1.8
+        final ThrowingRunnable testMethod = new ThrowingRunnable() {
+            public void run() {
+                DomainValidator.updateTLDOverride(ArrayType.COUNTRY_CODE_RO, new String[]{"com"});
+            }
+        };
+        final IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, testMethod);
+        assertThat(thrown.getMessage(), is(equalTo("Cannot update the table: COUNTRY_CODE_RO")));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testUpdateBaseArrayGeneric() {
-        DomainValidator.updateTLDOverride(ArrayType.GENERIC_RO, new String[]{"com"});
+        // FIXME Simplification once upgraded to Java 1.8
+        final ThrowingRunnable testMethod = new ThrowingRunnable() {
+            public void run() {
+                DomainValidator.updateTLDOverride(ArrayType.GENERIC_RO, new String[]{"com"});
+            }
+        };
+        final IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, testMethod);
+        assertThat(thrown.getMessage(), is(equalTo("Cannot update the table: GENERIC_RO")));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testUpdateBaseArrayInfra() {
-        DomainValidator.updateTLDOverride(ArrayType.INFRASTRUCTURE_RO, new String[]{"com"});
+        // FIXME Simplification once upgraded to Java 1.8
+        final ThrowingRunnable testMethod = new ThrowingRunnable() {
+            public void run() {
+                DomainValidator.updateTLDOverride(ArrayType.INFRASTRUCTURE_RO, new String[]{"com"});
+            }
+        };
+        final IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, testMethod);
+        assertThat(thrown.getMessage(), is(equalTo("Cannot update the table: INFRASTRUCTURE_RO")));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testUpdateBaseArrayLocal() {
-        DomainValidator.updateTLDOverride(ArrayType.LOCAL_RO, new String[]{"com"});
+        // FIXME Simplification once upgraded to Java 1.8
+        final ThrowingRunnable testMethod = new ThrowingRunnable() {
+            public void run() {
+                DomainValidator.updateTLDOverride(ArrayType.LOCAL_RO, new String[]{"com"});
+            }
+        };
+        final IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, testMethod);
+        assertThat(thrown.getMessage(), is(equalTo("Cannot update the table: LOCAL_RO")));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/validator/routines/EmailValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/EmailValidatorTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.commons.validator.routines;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.*;
 
 import java.util.ArrayList;
@@ -25,6 +28,7 @@ import org.apache.commons.validator.ResultPair;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
 
 /**
  * Performs Validation Test for e-mail validations.
@@ -565,21 +569,42 @@ public class EmailValidatorTest {
         assertTrue(validator.isValid("abc@school.school"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testValidator473_1() { // reject null DomainValidator
-        new EmailValidator(false, false, null);
+        // FIXME Simplification once upgraded to Java 1.8
+        final ThrowingRunnable testMethod = new ThrowingRunnable() {
+            public void run() {
+                new EmailValidator(false, false, null);
+            }
+        };
+        final IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, testMethod);
+        assertThat(thrown.getMessage(), is(equalTo("DomainValidator cannot be null")));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testValidator473_2() { // reject null DomainValidator with mismatched allowLocal
         final List<DomainValidator.Item> items = new ArrayList<>();
-        new EmailValidator(false, false, DomainValidator.getInstance(true, items));
+        // FIXME Simplification once upgraded to Java 1.8
+        final ThrowingRunnable testMethod = new ThrowingRunnable() {
+            public void run() {
+                new EmailValidator(false, false, DomainValidator.getInstance(true, items));
+            }
+        };
+        final IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, testMethod);
+        assertThat(thrown.getMessage(), is(equalTo("DomainValidator must agree with allowLocal setting")));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testValidator473_3() { // reject null DomainValidator with mismatched allowLocal
         final List<DomainValidator.Item> items = new ArrayList<>();
-        new EmailValidator(true, false, DomainValidator.getInstance(false, items));
+        // FIXME Simplification once upgraded to Java 1.8
+        final ThrowingRunnable testMethod = new ThrowingRunnable() {
+            public void run() {
+                new EmailValidator(true, false, DomainValidator.getInstance(false, items));
+            }
+        };
+        final IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, testMethod);
+        assertThat(thrown.getMessage(), is(equalTo("DomainValidator must agree with allowLocal setting")));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/validator/routines/IBANValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/IBANValidatorTest.java
@@ -16,9 +16,13 @@
  */
 package org.apache.commons.validator.routines;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -35,6 +39,7 @@ import org.apache.commons.csv.CSVRecord;
 import org.apache.commons.validator.routines.IBANValidator.Validator;
 import org.apache.commons.validator.routines.checkdigit.IBANCheckDigit;
 import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
 
 /**
  * IBANValidator Test Case.
@@ -184,32 +189,67 @@ public class IBANValidatorTest {
         assertNull("gb", VALIDATOR.getValidator("gb"));
     }
 
-    @Test(expected=IllegalStateException.class)
+    @Test
     public void testSetDefaultValidator1() {
-        assertNotNull(VALIDATOR.setValidator("GB", 15, "GB"));
+        // FIXME Simplification once upgraded to Java 1.8
+        final ThrowingRunnable testMethod = new ThrowingRunnable() {
+            public void run() {
+                assertNotNull(VALIDATOR.setValidator("GB", 15, "GB"));
+            }
+        };
+        final IllegalStateException thrown = assertThrows(IllegalStateException.class, testMethod);
+        assertThat(thrown.getMessage(), is(equalTo("The singleton validator cannot be modified")));
     }
 
-    @Test(expected=IllegalStateException.class)
+    @Test
     public void testSetDefaultValidator2() {
-        assertNotNull(VALIDATOR.setValidator("GB", -1, "GB"));
+        // FIXME Simplification once upgraded to Java 1.8
+        final ThrowingRunnable testMethod = new ThrowingRunnable() {
+            public void run() {
+                assertNotNull(VALIDATOR.setValidator("GB", -1, "GB"));
+            }
+        };
+        final IllegalStateException thrown = assertThrows(IllegalStateException.class, testMethod);
+        assertThat(thrown.getMessage(), is(equalTo("The singleton validator cannot be modified")));
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test
     public void testSetValidatorLC() {
         final IBANValidator validator = new IBANValidator();
-        assertNotNull(validator.setValidator("gb", 15, "GB"));
+        // FIXME Simplification once upgraded to Java 1.8
+        final ThrowingRunnable testMethod = new ThrowingRunnable() {
+            public void run() {
+                assertNotNull(validator.setValidator("gb", 15, "GB"));
+            }
+        };
+        final IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, testMethod);
+        assertThat(thrown.getMessage(), is(equalTo("Invalid country Code; must be exactly 2 upper-case characters")));
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test
     public void testSetValidatorLen7() {
         final IBANValidator validator = new IBANValidator();
-        assertNotNull(validator.setValidator("GB", 7, "GB"));
+        // FIXME Simplification once upgraded to Java 1.8
+        final ThrowingRunnable testMethod = new ThrowingRunnable() {
+            public void run() {
+                assertNotNull(validator.setValidator("GB", 7, "GB"));
+            }
+        };
+        final IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, testMethod);
+        assertThat(thrown.getMessage(), is(equalTo("Invalid length parameter, must be in range 8 to 34 inclusive: 7")));
     }
 
-    @Test(expected=IllegalArgumentException.class)
+    @Test
     public void testSetValidatorLen35() {
         final IBANValidator validator = new IBANValidator();
-        assertNotNull(validator.setValidator("GB", 35, "GB")); // valid params, but immutable validator
+        // FIXME Simplification once upgraded to Java 1.8
+        final ThrowingRunnable testMethod = new ThrowingRunnable() {
+            public void run() {
+                assertNotNull(validator.setValidator("GB", 35, "GB")); // valid params, but immutable validator
+            }
+        };
+        final IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, testMethod);
+        assertThat(thrown.getMessage(), is(equalTo("Invalid length parameter, must be in range 8 to 34 inclusive: 35")));
     }
 
     @Test

--- a/src/test/java/org/apache/commons/validator/routines/UrlValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/UrlValidatorTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.commons.validator.routines;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.Is.is;
+import static org.hamcrest.core.IsEqual.equalTo;
 import static org.junit.Assert.*;
 
 import java.net.URI;
@@ -26,6 +29,7 @@ import java.util.List;
 import org.apache.commons.validator.ResultPair;
 import org.junit.Before;
 import org.junit.Test;
+import org.junit.function.ThrowingRunnable;
 
 /**
  * Performs Validation Test for url validations.
@@ -359,21 +363,42 @@ public class UrlValidatorTest {
       assertTrue(urlValidator.isValid("http://[::FFFF:129.144.52.38]:80/index.html"));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testValidator473_1() { // reject null DomainValidator
-        new UrlValidator(new String[]{}, null, 0L, null);
+        // FIXME Simplification once upgraded to Java 1.8
+        final ThrowingRunnable testMethod = new ThrowingRunnable() {
+            public void run() {
+                new UrlValidator(new String[]{}, null, 0L, null);
+            }
+        };
+        final IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, testMethod);
+        assertThat(thrown.getMessage(), is(equalTo("DomainValidator must not be null")));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testValidator473_2() { // reject null DomainValidator with mismatched allowLocal
         final List<DomainValidator.Item> items = new ArrayList<>();
-        new UrlValidator(new String[]{}, null, 0L, DomainValidator.getInstance(true, items));
+        // FIXME Simplification once upgraded to Java 1.8
+        final ThrowingRunnable testMethod = new ThrowingRunnable() {
+            public void run() {
+                new UrlValidator(new String[]{}, null, 0L, DomainValidator.getInstance(true, items));
+            }
+        };
+        final IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, testMethod);
+        assertThat(thrown.getMessage(), is(equalTo("DomainValidator disagrees with ALLOW_LOCAL_URLS setting")));
     }
 
-    @Test(expected = IllegalArgumentException.class)
+    @Test
     public void testValidator473_3() { // reject null DomainValidator with mismatched allowLocal
         final List<DomainValidator.Item> items = new ArrayList<>();
-        new UrlValidator(new String[]{}, null, UrlValidator.ALLOW_LOCAL_URLS, DomainValidator.getInstance(false, items));
+        // FIXME Simplification once upgraded to Java 1.8
+        final ThrowingRunnable testMethod = new ThrowingRunnable() {
+            public void run() {
+                new UrlValidator(new String[]{}, null, UrlValidator.ALLOW_LOCAL_URLS, DomainValidator.getInstance(false, items));
+            }
+        };
+        final IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class, testMethod);
+        assertThat(thrown.getMessage(), is(equalTo("DomainValidator disagrees with ALLOW_LOCAL_URLS setting")));
     }
 
     static boolean incrementTestPartsIndex(final int[] testPartsIndex, final Object[] testParts) {


### PR DESCRIPTION
Code could be cleaner if it could be Java 1.8.

I could set `<maven.compiler.testSource>1.8</maven.compiler.testSource>`... thoughts???