### PR TITLE
added special prefixes for ISINs

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/ISINValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/ISINValidator.java
@@ -63,6 +63,13 @@ public class ISINValidator implements Serializable {
     private static final String [] SPECIALS = {
             "EZ", // http://www.anna-web.org/standards/isin-iso-6166/
             "XS", // https://www.isin.org/isin/
+            "EU", // eg. EU0009652783, EU0009656420 - https://www.anna-web.org/wp-content/uploads/2019/12/ISIN-Guidelines-Version-16_clean.pdf
+            // see ISIN UNIFORM GUIDELINES RELATING TO ISO 6166 (9 th edition),  Version 16: December 2019
+            //  5. SUBSTITUTE NUMBERING AGENCIES (SNAs)
+            "XA", // internal CUSIP Global Services
+            "XB", // internal NSD Russia
+            "XC", // internal WM Datenservice Germany
+            "XD", // internal SIX Financial Information Ltd.
         };
 
     static {

--- a/src/test/java/org/apache/commons/validator/routines/ISINValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/ISINValidatorTest.java
@@ -44,6 +44,10 @@ public class ISINValidatorTest extends TestCase {
             "INE112A01023",
             "EZ0000000003", // Invented; for use in ISINValidator
             "XS0000000009",
+            "EU0009652783",
+            "XAC8614YAB92",
+            "XC0001458477",
+            "XD0209061296",
             };
 
     private final String[] invalidFormat = new String[] {


### PR DESCRIPTION
ISINs can have special prefixes accodring to ISIN ISO Standard.
Missing prefixes:
EU, XA, XB, XC, XD