### PR TITLE
Remove commons-collections; Replace FastHashMap with ConcurrentHashMap

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
 
   <groupId>commons-validator</groupId>
   <artifactId>commons-validator</artifactId>
-  <version>1.8-SNAPSHOT</version>
+  <version>1.8.brickst</version>
   <name>Apache Commons Validator</name>
   <description>
     Apache Commons Validator provides the building blocks for both client side validation and server side data validation.
@@ -40,7 +40,7 @@
     <commons.componentid>validator</commons.componentid>
     <commons.module.name>org.apache.commons.validator</commons.module.name>
     <!-- Re-generate the download page using: mvn commons:download-page -->
-    <commons.release.version>1.7</commons.release.version>
+    <commons.release.version>1.8.brickst</commons.release.version>
     <commons.rc.version>RC2</commons.rc.version>
     <commons.release.desc>(requires JDK ${maven.compiler.target})</commons.release.desc>
     <commons.bc.version>1.6</commons.bc.version>
@@ -51,8 +51,8 @@
     <commons.scmPubCheckoutDirectory>site-content</commons.scmPubCheckoutDirectory>
     <commons.scmPubUrl>https://svn.apache.org/repos/infra/websites/production/commons/content/proper/commons-validator</commons.scmPubUrl>
 
-    <maven.compiler.source>1.7</maven.compiler.source>
-    <maven.compiler.target>1.7</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <commons.release.isDistModule>true</commons.release.isDistModule>
@@ -131,12 +131,19 @@
     </plugins>
   </build>
 
+  <repositories>
+    <repository>
+      <id>jitpack.io</id>
+      <url>https://jitpack.io</url>
+    </repository>
+  </repositories>
+
   <dependencies>
 
     <dependency>
-      <groupId>commons-beanutils</groupId>
+      <groupId>com.github.BrickStreetSoftware</groupId>
       <artifactId>commons-beanutils</artifactId>
-      <version>1.9.4</version>
+      <version>c5585f2</version>
     </dependency>
 
     <dependency>
@@ -160,12 +167,6 @@
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
       <version>1.2</version>
-    </dependency>
-
-    <dependency>
-      <groupId>commons-collections</groupId>
-      <artifactId>commons-collections</artifactId>
-      <version>3.2.2</version>
     </dependency>
 
     <!-- Needed for IBANValidatorTest -->

--- a/src/main/java/org/apache/commons/validator/Field.java
+++ b/src/main/java/org/apache/commons/validator/Field.java
@@ -27,9 +27,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.StringTokenizer;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.beanutils.PropertyUtils;
-import org.apache.commons.collections.FastHashMap; // DEPRECATED
 import org.apache.commons.validator.util.ValidatorUtils;
 
 /**
@@ -37,10 +37,6 @@ import org.apache.commons.validator.util.ValidatorUtils;
  * message information and variables to perform the validations and generate
  * error messages.  Instances of this class are configured with a
  * &lt;field&gt; xml element.
- * <p>
- * The use of FastHashMap is deprecated and will be replaced in a future
- * release.
- * </p>
  *
  * @version $Revision$
  * @see org.apache.commons.validator.Form
@@ -131,13 +127,13 @@ public class Field implements Cloneable, Serializable {
      * @deprecated Subclasses should use getVarMap() instead.
      */
     @Deprecated
-    protected FastHashMap hVars = new FastHashMap(); // <String, Var>
+    protected ConcurrentHashMap<String,Var> hVars = new ConcurrentHashMap<>(); // <String, Var>
 
     /**
      * @deprecated Subclasses should use getMsgMap() instead.
      */
     @Deprecated
-    protected FastHashMap hMsgs = new FastHashMap(); // <String, Msg>
+    protected ConcurrentHashMap<String,Msg> hMsgs = new ConcurrentHashMap<>(); // <String, Msg>
 
     /**
      * Holds Maps of arguments.  args[0] returns the Map for the first
@@ -560,9 +556,6 @@ public class Field implements Cloneable, Serializable {
      * to create the dependency <code>Map</code>.
      */
     void process(Map<String, String> globalConstants, Map<String, String> constants) {
-        this.hMsgs.setFast(false);
-        this.hVars.setFast(true);
-
         this.generateKey();
 
         // Process FormSet Constants
@@ -599,8 +592,6 @@ public class Field implements Cloneable, Serializable {
 
             this.processMessageComponents(key2, replaceValue);
         }
-
-        hMsgs.setFast(true);
     }
 
     /**
@@ -705,8 +696,8 @@ public class Field implements Cloneable, Serializable {
             field.args[i] = argMap;
         }
 
-        field.hVars = ValidatorUtils.copyFastHashMap(hVars);
-        field.hMsgs = ValidatorUtils.copyFastHashMap(hMsgs);
+        field.hVars = ValidatorUtils.copyMap(hVars);
+        field.hMsgs = ValidatorUtils.copyMap(hMsgs);
 
         return field;
     }
@@ -934,7 +925,6 @@ public class Field implements Cloneable, Serializable {
      * @since Validator 1.2.0
      * @return A Map of the Field's messages.
      */
-    @SuppressWarnings("unchecked") // FastHashMap does not support generics
     protected Map<String, Msg> getMsgMap() {
         return hMsgs;
     }
@@ -944,7 +934,6 @@ public class Field implements Cloneable, Serializable {
      * @since Validator 1.2.0
      * @return A Map of the Field's variables.
      */
-    @SuppressWarnings("unchecked") // FastHashMap does not support generics
     protected Map<String, Var> getVarMap() {
         return hVars;
     }

--- a/src/main/java/org/apache/commons/validator/Form.java
+++ b/src/main/java/org/apache/commons/validator/Form.java
@@ -22,18 +22,14 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-
-import org.apache.commons.collections.FastHashMap;// DEPRECATED
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * <p>
  *
  * This contains a set of validation rules for a form/JavaBean. The information
  * is contained in a list of <code>Field</code> objects. Instances of this class
- * are configured with a &lt;form&gt; xml element. </p> <p>
- *
- * The use of FastHashMap is deprecated and will be replaced in a future
- * release. </p>
+ * are configured with a &lt;form&gt; xml element. </p>
  *
  * @version $Revision$
  */
@@ -57,8 +53,7 @@ public class Form implements Serializable {
      *
      * @deprecated   Subclasses should use getFieldMap() instead.
      */
-    @Deprecated
-    protected FastHashMap hFields = new FastHashMap(); // <String, Field>
+    protected ConcurrentHashMap<String,Field> hFields = new ConcurrentHashMap<>(); // <String, Field>
 
     /**
      * The name/key of the form which this form extends from.
@@ -145,8 +140,7 @@ public class Form implements Serializable {
     protected void merge(Form depends) {
 
         List<Field> templFields = new ArrayList<>();
-        @SuppressWarnings("unchecked") // FastHashMap is not generic
-        Map<String, Field> temphFields = new FastHashMap();
+	Map<String, Field> temphFields = new ConcurrentHashMap<String,Field>();
         Iterator<Field> dependsIt = depends.getFields().iterator();
         while (dependsIt.hasNext()) {
             Field defaultField = dependsIt.next();
@@ -200,7 +194,6 @@ public class Form implements Serializable {
                 }
             }
         }
-        hFields.setFast(true);
         //no need to reprocess parent's fields, we iterate from 'n'
         for (Iterator<Field> i = lFields.listIterator(n); i.hasNext(); ) {
             Field f = i.next();
@@ -344,7 +337,6 @@ public class Form implements Serializable {
      * @return   The fieldMap value
      * @since    Validator 1.2.0
      */
-    @SuppressWarnings("unchecked") // FastHashMap is not generic
     protected Map<String, Field> getFieldMap() {
         return hFields;
     }

--- a/src/main/java/org/apache/commons/validator/ValidatorResources.java
+++ b/src/main/java/org/apache/commons/validator/ValidatorResources.java
@@ -23,8 +23,8 @@ import java.net.URL;
 import java.util.Collections;
 import java.util.Locale;
 import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
-import org.apache.commons.collections.FastHashMap; // DEPRECATED
 import org.apache.commons.digester.Digester;
 import org.apache.commons.digester.Rule;
 import org.apache.commons.digester.xmlrules.DigesterLoader;
@@ -43,11 +43,6 @@ import org.xml.sax.Attributes;
  * <p><strong>Note</strong> - Classes that extend this class
  * must be Serializable so that instances may be used in distributable
  * application server environments.</p>
- *
- * <p>
- * The use of FastHashMap is deprecated and will be replaced in a future
- * release.
- * </p>
  *
  * @version $Revision$
  */
@@ -89,7 +84,7 @@ public class ValidatorResources implements Serializable {
      * @deprecated Subclasses should use getFormSets() instead.
      */
     @Deprecated
-    protected FastHashMap hFormSets = new FastHashMap(); // <String, FormSet>
+    protected ConcurrentHashMap<String,FormSet> hFormSets = new ConcurrentHashMap<>(); // <String, FormSet>
 
     /**
      * <code>Map</code> of global constant values with
@@ -97,7 +92,7 @@ public class ValidatorResources implements Serializable {
      * @deprecated Subclasses should use getConstants() instead.
      */
     @Deprecated
-    protected FastHashMap hConstants = new FastHashMap(); // <String, String>
+    protected ConcurrentHashMap<String,String> hConstants = new ConcurrentHashMap<>(); // <String, String>
 
     /**
      * <code>Map</code> of <code>ValidatorAction</code>s with
@@ -105,7 +100,7 @@ public class ValidatorResources implements Serializable {
      * @deprecated Subclasses should use getActions() instead.
      */
     @Deprecated
-    protected FastHashMap hActions = new FastHashMap(); // <String, ValidatorAction>
+    protected ConcurrentHashMap<String,ValidatorAction> hActions = new ConcurrentHashMap<>(); // <String, ValidatorAction>
 
     /**
      * The default locale on our server.
@@ -515,10 +510,6 @@ public class ValidatorResources implements Serializable {
      * this method when finished.
      */
     public void process() {
-        hFormSets.setFast(true);
-        hConstants.setFast(true);
-        hActions.setFast(true);
-
         this.processForms();
     }
 
@@ -607,7 +598,6 @@ public class ValidatorResources implements Serializable {
      * @return Map of Form sets
      * @since Validator 1.2.0
      */
-    @SuppressWarnings("unchecked") // FastHashMap is not generic
     protected Map<String, FormSet> getFormSets() {
         return hFormSets;
     }
@@ -617,7 +607,6 @@ public class ValidatorResources implements Serializable {
      * @return Map of Constants
      * @since Validator 1.2.0
      */
-    @SuppressWarnings("unchecked") // FastHashMap is not generic
     protected Map<String, String> getConstants() {
         return hConstants;
     }
@@ -627,7 +616,6 @@ public class ValidatorResources implements Serializable {
      * @return Map of Validator Actions
      * @since Validator 1.2.0
      */
-    @SuppressWarnings("unchecked") // FastHashMap is not generic
     protected Map<String, ValidatorAction> getActions() {
         return hActions;
     }

--- a/src/main/java/org/apache/commons/validator/util/ValidatorUtils.java
+++ b/src/main/java/org/apache/commons/validator/util/ValidatorUtils.java
@@ -18,13 +18,12 @@ package org.apache.commons.validator.util;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
 
 import org.apache.commons.beanutils.PropertyUtils;
-import org.apache.commons.collections.FastHashMap; // DEPRECATED
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.apache.commons.validator.Arg;
@@ -33,10 +32,6 @@ import org.apache.commons.validator.Var;
 
 /**
  * Basic utility methods.
- * <p>
- * The use of FastHashMap is deprecated and will be replaced in a future
- * release.
- * </p>
  *
  * @version $Revision$
  */
@@ -125,44 +120,6 @@ public class ValidatorUtils {
     }
 
     /**
-     * Makes a deep copy of a <code>FastHashMap</code> if the values
-     * are <code>Msg</code>, <code>Arg</code>,
-     * or <code>Var</code>.  Otherwise it is a shallow copy.
-     *
-     * @param map <code>FastHashMap</code> to copy.
-     * @return FastHashMap A copy of the <code>FastHashMap</code> that was
-     * passed in.
-     * @deprecated This method is not part of Validator's public API.  Validator
-     * will use it internally until FastHashMap references are removed.  Use
-     * copyMap() instead.
-     */
-    @Deprecated
-    public static FastHashMap copyFastHashMap(FastHashMap map) {
-        FastHashMap results = new FastHashMap();
-
-        @SuppressWarnings("unchecked") // FastHashMap is not generic
-        Iterator<Entry<String, ?>> i = map.entrySet().iterator();
-        while (i.hasNext()) {
-            Entry<String, ?> entry = i.next();
-            String key = entry.getKey();
-            Object value = entry.getValue();
-
-            if (value instanceof Msg) {
-                results.put(key, ((Msg) value).clone());
-            } else if (value instanceof Arg) {
-                results.put(key, ((Arg) value).clone());
-            } else if (value instanceof Var) {
-                results.put(key, ((Var) value).clone());
-            } else {
-                results.put(key, value);
-            }
-        }
-
-        results.setFast(true);
-        return results;
-    }
-
-    /**
      * Makes a deep copy of a <code>Map</code> if the values are
      * <code>Msg</code>, <code>Arg</code>, or <code>Var</code>.  Otherwise,
      * it is a shallow copy.
@@ -171,21 +128,21 @@ public class ValidatorUtils {
      *
      * @return A copy of the <code>Map</code> that was passed in.
      */
-    public static Map<String, Object> copyMap(Map<String, Object> map) {
-        Map<String, Object> results = new HashMap<>();
+    public static <T> ConcurrentHashMap<String, T> copyMap(Map<String, T> map) {
+        ConcurrentHashMap<String, T> results = new ConcurrentHashMap<>();
 
-        Iterator<Entry<String, Object>> i = map.entrySet().iterator();
+        Iterator<Entry<String, T>> i = map.entrySet().iterator();
         while (i.hasNext()) {
-            Entry<String, Object> entry = i.next();
+            Entry<String, T> entry = i.next();
             String key = entry.getKey();
-            Object value = entry.getValue();
+            T value = entry.getValue();
 
             if (value instanceof Msg) {
-                results.put(key, ((Msg) value).clone());
+                results.put(key, (T) ((Msg) value).clone());
             } else if (value instanceof Arg) {
-                results.put(key, ((Arg) value).clone());
+                results.put(key, (T) ((Arg) value).clone());
             } else if (value instanceof Var) {
-                results.put(key, ((Var) value).clone());
+                results.put(key, (T) ((Var) value).clone());
             } else {
                 results.put(key, value);
             }


### PR DESCRIPTION
We needed to eliminate commons-collections 3 for a large corp. due to security concerns.

This replaces FastHashMap with ConcurrentHashMap and removes commons-collections.

FYI We also submitted a PR to commons-beanutils2 to modify that repo to be a commons-collections -free version that can replace beanutils 1.9.4.  