### PR TITLE
refactor: refactor bad smell ToArrayCallWithZeroLengthArrayArgument

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/InetAddressValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/InetAddressValidator.java
@@ -170,7 +170,7 @@ public class InetAddressValidator implements Serializable {
             } else if (inet6Address.startsWith("::") && !octetList.isEmpty()) {
                 octetList.remove(0);
             }
-            octets = octetList.toArray(new String[octetList.size()]);
+            octets = octetList.toArray(new String[0]);
         }
         if (octets.length > IPV6_MAX_HEX_GROUPS) {
             return false;


### PR DESCRIPTION
# Repairing Code Style Issues
<!-- laughing-train-refactor -->
## ToArrayCallWithZeroLengthArrayArgument
The performance of the empty array version is the same, and sometimes even better, compared
to the pre-sized version. Also, passing a pre-sized array is dangerous for a concurrent or
synchronized collection as a data race is possible between the <code>size</code> and <code>toArray</code>
calls. This may result in extra <code>null</code>s at the end of the array if the collection was concurrently
shrunk during the operation.</p>
See https://shipilev.net/blog/2016/arrays-wisdom-ancients/ for more details.

<!-- fingerprint:-333291108 -->
# Repairing Code Style Issues
* ToArrayCallWithZeroLengthArrayArgument (1)
