### PR TITLE
bump commons-commons-collections-4.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -163,7 +163,7 @@
     <dependency>
       <groupId>commons-collections</groupId>
       <artifactId>commons-collections</artifactId>
-      <version>3.2.2</version>
+      <version>4.4.0</version>
     </dependency>
 
     <!-- Needed for IBANValidatorTest -->


### PR DESCRIPTION
Hello,

I noticed in my editor that there is some vulnerability reported.

![image](https://github.com/apache/commons-validator/assets/3184228/cba8e919-7771-4d88-a16a-641b9428e664)

Problem is that affected dependency [commons-collection](https://github.com/apache/commons-collections) do not have a new releases on maven repository: https://repo.maven.apache.org/maven2/commons-collections/commons-collections/

However there are new releases under bigger tags than original 3.2.2, see: 
https://github.com/apache/commons-collections/releases/tag/commons-commons-collections-4.4

I don't know why. Can you please check it with the responsible people? I don't know how to connect to the correct mailing list, write there. I would love to write it as a GitHub issue but it's not possible.

So I did this dump pull request to let you know, and ask you to help me with that.


