### PR TITLE
Validator CASNumberCheckDigit for Chemical Registry CAS Numbers and ECNumberCheckDigit

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigit.java
@@ -44,9 +44,9 @@ import org.apache.commons.validator.routines.CodeValidator;
  */
 public final class CASNumberCheckDigit extends ModulusCheckDigit {
 
-	private static final long serialVersionUID = -5387334603220786657L;
+    private static final long serialVersionUID = -5387334603220786657L;
 
-	/** Singleton Check Digit instance */
+    /** Singleton Check Digit instance */
     public static final CheckDigit CAS_CHECK_DIGIT = new CASNumberCheckDigit();
 
     /**

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigit.java
@@ -115,14 +115,14 @@ public final class CASNumberCheckDigit extends ModulusCheckDigit {
         Object cde = REGEX_VALIDATOR.validate(code);
         if (cde instanceof String) {
             try {
-        	    final int modulusResult = calculateModulus((String)cde, true);
-//        		System.out.println("modulusResult="+modulusResult + " for code "+code);
-        		return modulusResult == Character.getNumericValue(code.charAt(code.length() - 1));
-        	} catch (final CheckDigitException ex) {
-        		return false;
-        	}
+                final int modulusResult = calculateModulus((String)cde, true);
+//              System.out.println("modulusResult="+modulusResult + " for code "+code);
+                return modulusResult == Character.getNumericValue(code.charAt(code.length() - 1));
+            } catch (final CheckDigitException ex) {
+                return false;
+            }
         } else {
-        	return false;
+            return false;
         }
     }
 

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigit.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.validator.routines.checkdigit;
+
+import org.apache.commons.validator.routines.CodeValidator;
+
+/**
+ * Modulus 10 <b>CAS Registry Number</b> (or <b>Chemical Abstracts Service</b> (CAS RN)) Check Digit
+ * calculation/validation.
+ *
+ * <p>
+ * CAS Numbers are unique identification numbers used
+ * to identify chemical substance described in the open scientific literature.
+ * </p>
+ *
+ * Check digit calculation is based on <i>modulus 10</i> with digits being weighted
+ * based on their position (from right to left).
+ * 
+ * The check digit is found by taking the last digit times 1, the preceding digit times 2, 
+ * the preceding digit times 3 etc., adding all these up and computing the sum modulo 10. 
+ * For example, the CAS number of water is 7732-18-5: 
+ * the checksum 5 is calculated as (8×1 + 1×2 + 2×3 + 3×4 + 7×5 + 7×6) = 105; 105 mod 10 = 5.
+ *
+ * <p>
+ * For further information see
+ *  <a href="https://en.wikipedia.org/wiki/CAS_Registry_Number">Wikipedia - CAS Registry Number</a>.
+ * </p>
+ *
+ * @since 1.9
+ */
+public final class CASNumberCheckDigit extends ModulusCheckDigit {
+
+	private static final long serialVersionUID = -5387334603220786657L;
+
+	/** Singleton Check Digit instance */
+    public static final CheckDigit CAS_CHECK_DIGIT = new CASNumberCheckDigit();
+
+    /**
+     * CAS number consists of 3 groups of numbers separated dashes (-).
+     * First group up to 7 digits.
+     * Example: water is 7732-18-5
+     */
+    private static final String GROUP1 = "(\\d{1,7})";
+    private static final String DASH = "(?:\\-)";
+    static final String CAS_REGEX = "^(?:" + GROUP1 + DASH + "(\\d{2})" + DASH + "(\\d))$";
+    
+    private static final int CAS_MIN_LEN = 4; // 9-99-9 LEN without SEP
+    /** maximum capacity of 1,000,000,000 == 9999999-99-9*/
+    private static final int CAS_MAX_LEN = 10;
+    static final CodeValidator REGEX_VALIDATOR = new CodeValidator(CAS_REGEX, CAS_MIN_LEN, CAS_MAX_LEN, null);
+    
+    /** Weighting given to digits depending on their right position */
+    private static final int[] POSITION_WEIGHT = { 0,1,2,3,4,5,6,7,8,9 };
+
+    /**
+     * Constructs a modulus 10 Check Digit routine for CAS Numbers.
+     */
+    public CASNumberCheckDigit() {
+    }
+
+    /**
+     * Calculates the <i>weighted</i> value of a character in the code at a specified position.
+     * <p>
+     * CAS numbers are weighted in the following manner:
+     * <pre><code>
+     *    right position: 1  2  3  4  5  6  7  8  9 10
+     *            weight: 1  2  3  4  5  6  7  8  9  0
+     * </code></pre>
+     *
+     * @param charValue The numeric value of the character.
+     * @param leftPos The position of the character in the code, counting from left to right
+     * @param rightPos The positionof the character in the code, counting from right to left
+     * @return The weighted value of the character.
+     */
+    @Override
+    protected int weightedValue(final int charValue, final int leftPos, final int rightPos) {
+        final int weight = POSITION_WEIGHT[(rightPos-1) % 10];
+        return charValue * weight;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String calculate(final String code) throws CheckDigitException {
+        if (code == null || code.isEmpty()) {
+            throw new CheckDigitException("Code is missing");
+        }
+        final int modulusResult = calculateModulus(code, false);
+        return toCheckDigit(modulusResult);
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isValid(final String code) {
+        if (code == null || code.isEmpty()) {
+            return false;
+        }
+        Object cde = REGEX_VALIDATOR.validate(code);
+        if(cde instanceof String) {
+        	try {
+        		final int modulusResult = calculateModulus((String)cde, true);
+//        		System.out.println("modulusResult="+modulusResult + " for code "+code);
+        		return modulusResult == Character.getNumericValue(code.charAt(code.length() - 1));
+        	} catch (final CheckDigitException ex) {
+        		return false;
+        	}
+        } else {
+        	return false;
+        }
+    }
+
+}

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigit.java
@@ -40,7 +40,7 @@ import org.apache.commons.validator.routines.CodeValidator;
  *  <a href="https://en.wikipedia.org/wiki/CAS_Registry_Number">Wikipedia - CAS Registry Number</a>.
  * </p>
  *
- * @since 1.9
+ * @since 1.9.0
  */
 public final class CASNumberCheckDigit extends ModulusCheckDigit {
 
@@ -100,7 +100,7 @@ public final class CASNumberCheckDigit extends ModulusCheckDigit {
         if (code == null || code.isEmpty()) {
             throw new CheckDigitException("Code is missing");
         }
-        final int modulusResult = calculateModulus(code, false);
+        int modulusResult = calculateModulus(code, false);
         return toCheckDigit(modulusResult);
     }
 
@@ -116,7 +116,6 @@ public final class CASNumberCheckDigit extends ModulusCheckDigit {
         if (cde instanceof String) {
             try {
                 final int modulusResult = calculateModulus((String)cde, true);
-//              System.out.println("modulusResult="+modulusResult + " for code "+code);
                 return modulusResult == Character.getNumericValue(code.charAt(code.length() - 1));
             } catch (final CheckDigitException ex) {
                 return false;

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigit.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.validator.routines.checkdigit;
 
+import org.apache.commons.validator.GenericValidator;
 import org.apache.commons.validator.routines.CodeValidator;
 
 /**
@@ -110,7 +111,7 @@ public final class CASNumberCheckDigit extends ModulusCheckDigit {
      */
     @Override
     public String calculate(final String code) throws CheckDigitException {
-        if (isEmpty(code)) {
+        if (GenericValidator.isBlankOrNull(code)) {
             throw new CheckDigitException("Code is missing");
         }
         int modulusResult = INSTANCE.calculateModulus(code, false);
@@ -122,7 +123,7 @@ public final class CASNumberCheckDigit extends ModulusCheckDigit {
      */
     @Override
     public boolean isValid(final String code) {
-        if (isEmpty(code)) {
+        if (GenericValidator.isBlankOrNull(code)) {
             return false;
         }
         Object cde = REGEX_VALIDATOR.validate(code);

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigit.java
@@ -27,13 +27,17 @@ import org.apache.commons.validator.routines.CodeValidator;
  * to identify chemical substance described in the open scientific literature.
  * </p>
  *
+ * <p>
  * Check digit calculation is based on <i>modulus 10</i> with digits being weighted
  * based on their position (from right to left).
+ * </p>
  *
+ * <p>
  * The check digit is found by taking the last digit times 1, the preceding digit times 2,
  * the preceding digit times 3 etc., adding all these up and computing the sum modulo 10.
- * For example, the CAS number of water is 7732-18-5:
+ * For example, the CAS number of water is <code>7732-18-5</code>:
  * the checksum 5 is calculated as (8×1 + 1×2 + 2×3 + 3×4 + 7×5 + 7×6) = 105; 105 mod 10 = 5.
+ * </p>
  *
  * <p>
  * For further information see
@@ -47,7 +51,15 @@ public final class CASNumberCheckDigit extends ModulusCheckDigit {
     private static final long serialVersionUID = -5387334603220786657L;
 
     /** Singleton Check Digit instance */
-    public static final CheckDigit CAS_CHECK_DIGIT = new CASNumberCheckDigit();
+    private static final CheckDigit INSTANCE = new CASNumberCheckDigit();
+    
+    /**
+     * Gets the singleton instance of this validator.
+     * @return A singleton instance of the CAS Number validator.
+     */
+    public static CheckDigit getInstance() {
+        return INSTANCE;
+    }
 
     /**
      * CAS number consists of 3 groups of numbers separated dashes (-).
@@ -69,7 +81,7 @@ public final class CASNumberCheckDigit extends ModulusCheckDigit {
     /**
      * Constructs a modulus 10 Check Digit routine for CAS Numbers.
      */
-    public CASNumberCheckDigit() {
+    private CASNumberCheckDigit() {
     }
 
     /**

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigit.java
@@ -64,10 +64,10 @@ public final class CASNumberCheckDigit extends ModulusCheckDigit {
 
     /**
      * CAS number consists of 3 groups of numbers separated dashes (-).
-     * First group up to 7 digits.
+     * First group has 2 to 7 digits.
      * Example: water is 7732-18-5
      */
-    private static final String GROUP1 = "(\\d{1,7})";
+    private static final String GROUP1 = "(\\d{2,7})";
     private static final String DASH = "(?:\\-)";
     static final String CAS_REGEX = "^(?:" + GROUP1 + DASH + "(\\d{2})" + DASH + "(\\d))$";
 

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigit.java
@@ -115,7 +115,7 @@ public final class CASNumberCheckDigit extends ModulusCheckDigit {
         Object cde = REGEX_VALIDATOR.validate(code);
         if (cde instanceof String) {
         	try {
-        		final int modulusResult = calculateModulus((String)cde, true);
+        	    final int modulusResult = calculateModulus((String)cde, true);
 //        		System.out.println("modulusResult="+modulusResult + " for code "+code);
         		return modulusResult == Character.getNumericValue(code.charAt(code.length() - 1));
         	} catch (final CheckDigitException ex) {

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigit.java
@@ -51,7 +51,7 @@ public final class CASNumberCheckDigit extends ModulusCheckDigit {
     private static final long serialVersionUID = -5387334603220786657L;
 
     /** Singleton Check Digit instance */
-    private static final CheckDigit INSTANCE = new CASNumberCheckDigit();
+    private static final CASNumberCheckDigit INSTANCE = new CASNumberCheckDigit();
 
     /**
      * Gets the singleton instance of this validator.
@@ -76,7 +76,7 @@ public final class CASNumberCheckDigit extends ModulusCheckDigit {
     static final CodeValidator REGEX_VALIDATOR = new CodeValidator(CAS_REGEX, CAS_MIN_LEN, CAS_MAX_LEN, null);
 
     /** Weighting given to digits depending on their right position */
-    private static final int[] POSITION_WEIGHT = { 0,1,2,3,4,5,6,7,8,9 };
+    private static final int[] POSITION_WEIGHT = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
 
     /**
      * Constructs a modulus 10 Check Digit routine for CAS Numbers.
@@ -88,6 +88,7 @@ public final class CASNumberCheckDigit extends ModulusCheckDigit {
      * Calculates the <i>weighted</i> value of a character in the code at a specified position.
      * <p>
      * CAS numbers are weighted in the following manner:
+     * </p>
      * <pre><code>
      *    right position: 1  2  3  4  5  6  7  8  9 10
      *            weight: 1  2  3  4  5  6  7  8  9  0
@@ -109,10 +110,10 @@ public final class CASNumberCheckDigit extends ModulusCheckDigit {
      */
     @Override
     public String calculate(final String code) throws CheckDigitException {
-        if (code == null || code.isEmpty()) {
+        if (isEmpty(code)) {
             throw new CheckDigitException("Code is missing");
         }
-        int modulusResult = calculateModulus(code, false);
+        int modulusResult = INSTANCE.calculateModulus(code, false);
         return toCheckDigit(modulusResult);
     }
 
@@ -121,13 +122,13 @@ public final class CASNumberCheckDigit extends ModulusCheckDigit {
      */
     @Override
     public boolean isValid(final String code) {
-        if (code == null || code.isEmpty()) {
+        if (isEmpty(code)) {
             return false;
         }
         Object cde = REGEX_VALIDATOR.validate(code);
         if (cde instanceof String) {
             try {
-                final int modulusResult = calculateModulus((String)cde, true);
+                final int modulusResult = INSTANCE.calculateModulus((String) cde, true);
                 return modulusResult == Character.getNumericValue(code.charAt(code.length() - 1));
             } catch (final CheckDigitException ex) {
                 return false;

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigit.java
@@ -52,7 +52,7 @@ public final class CASNumberCheckDigit extends ModulusCheckDigit {
 
     /** Singleton Check Digit instance */
     private static final CheckDigit INSTANCE = new CASNumberCheckDigit();
-    
+
     /**
      * Gets the singleton instance of this validator.
      * @return A singleton instance of the CAS Number validator.

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigit.java
@@ -114,7 +114,7 @@ public final class CASNumberCheckDigit extends ModulusCheckDigit {
         }
         Object cde = REGEX_VALIDATOR.validate(code);
         if (cde instanceof String) {
-        	try {
+            try {
         	    final int modulusResult = calculateModulus((String)cde, true);
 //        		System.out.println("modulusResult="+modulusResult + " for code "+code);
         		return modulusResult == Character.getNumericValue(code.charAt(code.length() - 1));

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigit.java
@@ -29,10 +29,10 @@ import org.apache.commons.validator.routines.CodeValidator;
  *
  * Check digit calculation is based on <i>modulus 10</i> with digits being weighted
  * based on their position (from right to left).
- * 
- * The check digit is found by taking the last digit times 1, the preceding digit times 2, 
- * the preceding digit times 3 etc., adding all these up and computing the sum modulo 10. 
- * For example, the CAS number of water is 7732-18-5: 
+ *
+ * The check digit is found by taking the last digit times 1, the preceding digit times 2,
+ * the preceding digit times 3 etc., adding all these up and computing the sum modulo 10.
+ * For example, the CAS number of water is 7732-18-5:
  * the checksum 5 is calculated as (8×1 + 1×2 + 2×3 + 3×4 + 7×5 + 7×6) = 105; 105 mod 10 = 5.
  *
  * <p>
@@ -57,12 +57,12 @@ public final class CASNumberCheckDigit extends ModulusCheckDigit {
     private static final String GROUP1 = "(\\d{1,7})";
     private static final String DASH = "(?:\\-)";
     static final String CAS_REGEX = "^(?:" + GROUP1 + DASH + "(\\d{2})" + DASH + "(\\d))$";
-    
+
     private static final int CAS_MIN_LEN = 4; // 9-99-9 LEN without SEP
     /** maximum capacity of 1,000,000,000 == 9999999-99-9*/
     private static final int CAS_MAX_LEN = 10;
     static final CodeValidator REGEX_VALIDATOR = new CodeValidator(CAS_REGEX, CAS_MIN_LEN, CAS_MAX_LEN, null);
-    
+
     /** Weighting given to digits depending on their right position */
     private static final int[] POSITION_WEIGHT = { 0,1,2,3,4,5,6,7,8,9 };
 
@@ -88,7 +88,7 @@ public final class CASNumberCheckDigit extends ModulusCheckDigit {
      */
     @Override
     protected int weightedValue(final int charValue, final int leftPos, final int rightPos) {
-        final int weight = POSITION_WEIGHT[(rightPos-1) % 10];
+        final int weight = POSITION_WEIGHT[(rightPos - 1) % MODULUS_10];
         return charValue * weight;
     }
 
@@ -103,7 +103,7 @@ public final class CASNumberCheckDigit extends ModulusCheckDigit {
         final int modulusResult = calculateModulus(code, false);
         return toCheckDigit(modulusResult);
     }
-    
+
     /**
      * {@inheritDoc}
      */
@@ -113,7 +113,7 @@ public final class CASNumberCheckDigit extends ModulusCheckDigit {
             return false;
         }
         Object cde = REGEX_VALIDATOR.validate(code);
-        if(cde instanceof String) {
+        if (cde instanceof String) {
         	try {
         		final int modulusResult = calculateModulus((String)cde, true);
 //        		System.out.println("modulusResult="+modulusResult + " for code "+code);

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigit.java
@@ -27,9 +27,10 @@ import org.apache.commons.validator.routines.CodeValidator;
  * For example, the EC number of arsenic is 231-148-6:
  * </p>
  *
+ * <p>
  * Check digit calculation is based on <i>modulus 11</i> with digits being weighted
  * based on their position (from left to right).
- * <p>
+ * </p>
  *
  * <p>
  * For further information see
@@ -43,7 +44,15 @@ public final class ECNumberCheckDigit extends ModulusCheckDigit {
     private static final long serialVersionUID = 7265356024784308367L;
 
     /** Singleton Check Digit instance */
-    public static final CheckDigit EC_CHECK_DIGIT = new ECNumberCheckDigit();
+    private static final CheckDigit INSTANCE = new ECNumberCheckDigit();
+    
+    /**
+     * Gets the singleton instance of this validator.
+     * @return A singleton instance of the EC Number validator.
+     */
+    public static CheckDigit getInstance() {
+        return INSTANCE;
+    }
 
     /**
      * EC number consists of 3 groups of numbers separated dashes (-).
@@ -59,7 +68,7 @@ public final class ECNumberCheckDigit extends ModulusCheckDigit {
     /**
      * Constructs a modulus 11 Check Digit routine.
      */
-    public ECNumberCheckDigit() {
+    private ECNumberCheckDigit() {
         super(MODULUS_11);
     }
 
@@ -76,7 +85,7 @@ public final class ECNumberCheckDigit extends ModulusCheckDigit {
      */
     @Override
     protected int weightedValue(final int charValue, final int leftPos, final int rightPos) {
-        return (leftPos >= EC_LEN) ? 0 : charValue * leftPos;
+        return leftPos >= EC_LEN ? 0 : charValue * leftPos;
     }
 
     /**

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigit.java
@@ -44,7 +44,7 @@ public final class ECNumberCheckDigit extends ModulusCheckDigit {
     private static final long serialVersionUID = 7265356024784308367L;
 
     /** Singleton Check Digit instance */
-    private static final CheckDigit INSTANCE = new ECNumberCheckDigit();
+    private static final ECNumberCheckDigit INSTANCE = new ECNumberCheckDigit();
 
     /**
      * Gets the singleton instance of this validator.
@@ -93,10 +93,10 @@ public final class ECNumberCheckDigit extends ModulusCheckDigit {
      */
     @Override
     public String calculate(final String code) throws CheckDigitException {
-        if (code == null || code.isEmpty()) {
+        if (isEmpty(code)) {
             throw new CheckDigitException("Code is missing");
         }
-        int modulusResult = calculateModulus(code, false);
+        int modulusResult = INSTANCE.calculateModulus(code, false);
         return toCheckDigit(modulusResult);
     }
 
@@ -105,13 +105,13 @@ public final class ECNumberCheckDigit extends ModulusCheckDigit {
      */
     @Override
     public boolean isValid(final String code) {
-        if (code == null || code.isEmpty()) {
+        if (isEmpty(code)) {
             return false;
         }
         Object cde = REGEX_VALIDATOR.validate(code);
         if (cde instanceof String) {
             try {
-                final int modulusResult = calculateModulus((String)cde, true);
+                final int modulusResult = INSTANCE.calculateModulus((String) cde, true);
                 return modulusResult == Character.getNumericValue(code.charAt(code.length() - 1));
             } catch (final CheckDigitException ex) {
                 return false;

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigit.java
@@ -102,14 +102,14 @@ public final class ECNumberCheckDigit extends ModulusCheckDigit {
         Object cde = REGEX_VALIDATOR.validate(code);
         if (cde instanceof String) {
             try {
-        	    final int modulusResult = calculateModulus((String)cde, true);
-//        		System.out.println("modulusResult="+modulusResult + " for code "+code);
-        		return modulusResult == Character.getNumericValue(code.charAt(code.length() - 1));
-        	} catch (final CheckDigitException ex) {
-        		return false;
-        	}
+                final int modulusResult = calculateModulus((String)cde, true);
+//              System.out.println("modulusResult="+modulusResult + " for code "+code);
+                return modulusResult == Character.getNumericValue(code.charAt(code.length() - 1));
+            } catch (final CheckDigitException ex) {
+                return false;
+            }
         } else {
-        	return false;
+            return false;
         }
     }
 

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigit.java
@@ -45,7 +45,7 @@ public final class ECNumberCheckDigit extends ModulusCheckDigit {
 
     /** Singleton Check Digit instance */
     private static final CheckDigit INSTANCE = new ECNumberCheckDigit();
-    
+
     /**
      * Gets the singleton instance of this validator.
      * @return A singleton instance of the EC Number validator.

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigit.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.validator.routines.checkdigit;
 
+import org.apache.commons.validator.GenericValidator;
 import org.apache.commons.validator.routines.CodeValidator;
 
 /**
@@ -93,7 +94,7 @@ public final class ECNumberCheckDigit extends ModulusCheckDigit {
      */
     @Override
     public String calculate(final String code) throws CheckDigitException {
-        if (isEmpty(code)) {
+        if (GenericValidator.isBlankOrNull(code)) {
             throw new CheckDigitException("Code is missing");
         }
         int modulusResult = INSTANCE.calculateModulus(code, false);
@@ -105,7 +106,7 @@ public final class ECNumberCheckDigit extends ModulusCheckDigit {
      */
     @Override
     public boolean isValid(final String code) {
-        if (isEmpty(code)) {
+        if (GenericValidator.isBlankOrNull(code)) {
             return false;
         }
         Object cde = REGEX_VALIDATOR.validate(code);

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigit.java
@@ -1,0 +1,116 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.validator.routines.checkdigit;
+
+import org.apache.commons.validator.routines.CodeValidator;
+
+/**
+ * Modulus 11 <b>EC number</b> Check Digit calculation/validation.
+ *
+ * <p>
+ * The European Community number (EC number) is a unique seven-digit identifier 
+ * that is assigned to chemical substances. 
+ * For example, the EC number of arsenic is 231-148-6: 
+ * </p>
+ *
+ * Check digit calculation is based on <i>modulus 11</i> with digits being weighted
+ * based on their position (from left to right).
+ * <p>
+ * 
+ * <p>
+ * For further information see
+ *  <a href="https://en.wikipedia.org/wiki/European_Community_number">Wikipedia - EC number</a>.
+ * </p>
+ *
+ * @since 1.9
+ */
+public final class ECNumberCheckDigit extends ModulusCheckDigit {
+
+	private static final long serialVersionUID = 7265356024784308367L;
+	
+	/** Singleton Check Digit instance */
+    public static final CheckDigit EC_CHECK_DIGIT = new ECNumberCheckDigit();
+
+    /**
+     * EC number consists of 3 groups of numbers separated dashes (-).
+     * Example: dexamethasone is 200-003-9
+     */
+    private static final String GROUP = "(\\d{3})";
+    private static final String DASH = "(?:\\-)";
+    static final String EC_REGEX = "^(?:" + GROUP + DASH + GROUP + DASH + "(\\d))$";
+    
+    private static final int EC_LEN = 7;
+    static final CodeValidator REGEX_VALIDATOR = new CodeValidator(EC_REGEX, EC_LEN, null);
+    
+    /**
+     * Constructs a modulus 11 Check Digit routine.
+     */
+    public ECNumberCheckDigit() {
+        super(MODULUS_11);
+    }
+
+    /**
+     * Calculates the <i>weighted</i> value of a character in the
+     * code at a specified position.
+     *
+     * <p>For EC number digits are weighted by their position from left to right.</p>
+     *
+     * @param charValue The numeric value of the character.
+     * @param leftPos The position of the character in the code, counting from left to right
+     * @param rightPos The positionof the character in the code, counting from right to left
+     * @return The weighted value of the character.
+     */
+    @Override
+    protected int weightedValue(final int charValue, final int leftPos, final int rightPos) {
+        return (leftPos>=EC_LEN) ? 0 : charValue * leftPos;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String calculate(final String code) throws CheckDigitException {
+        if (code == null || code.isEmpty()) {
+            throw new CheckDigitException("Code is missing");
+        }
+        final int modulusResult = calculateModulus(code, false);
+        return toCheckDigit(modulusResult);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isValid(final String code) {
+        if (code == null || code.isEmpty()) {
+            return false;
+        }
+        Object cde = REGEX_VALIDATOR.validate(code);
+        if(cde instanceof String) {
+        	try {
+        		final int modulusResult = calculateModulus((String)cde, true);
+//        		System.out.println("modulusResult="+modulusResult + " for code "+code);
+        		return modulusResult == Character.getNumericValue(code.charAt(code.length() - 1));
+        	} catch (final CheckDigitException ex) {
+        		return false;
+        	}
+        } else {
+        	return false;
+        }
+    }
+
+}

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigit.java
@@ -22,15 +22,15 @@ import org.apache.commons.validator.routines.CodeValidator;
  * Modulus 11 <b>EC number</b> Check Digit calculation/validation.
  *
  * <p>
- * The European Community number (EC number) is a unique seven-digit identifier 
- * that is assigned to chemical substances. 
- * For example, the EC number of arsenic is 231-148-6: 
+ * The European Community number (EC number) is a unique seven-digit identifier
+ * that is assigned to chemical substances.
+ * For example, the EC number of arsenic is 231-148-6:
  * </p>
  *
  * Check digit calculation is based on <i>modulus 11</i> with digits being weighted
  * based on their position (from left to right).
  * <p>
- * 
+ *
  * <p>
  * For further information see
  *  <a href="https://en.wikipedia.org/wiki/European_Community_number">Wikipedia - EC number</a>.
@@ -40,8 +40,8 @@ import org.apache.commons.validator.routines.CodeValidator;
  */
 public final class ECNumberCheckDigit extends ModulusCheckDigit {
 
-	private static final long serialVersionUID = 7265356024784308367L;
-	
+    private static final long serialVersionUID = 7265356024784308367L;
+
 	/** Singleton Check Digit instance */
     public static final CheckDigit EC_CHECK_DIGIT = new ECNumberCheckDigit();
 
@@ -52,10 +52,10 @@ public final class ECNumberCheckDigit extends ModulusCheckDigit {
     private static final String GROUP = "(\\d{3})";
     private static final String DASH = "(?:\\-)";
     static final String EC_REGEX = "^(?:" + GROUP + DASH + GROUP + DASH + "(\\d))$";
-    
+
     private static final int EC_LEN = 7;
     static final CodeValidator REGEX_VALIDATOR = new CodeValidator(EC_REGEX, EC_LEN, null);
-    
+
     /**
      * Constructs a modulus 11 Check Digit routine.
      */
@@ -76,7 +76,7 @@ public final class ECNumberCheckDigit extends ModulusCheckDigit {
      */
     @Override
     protected int weightedValue(final int charValue, final int leftPos, final int rightPos) {
-        return (leftPos>=EC_LEN) ? 0 : charValue * leftPos;
+        return (leftPos >= EC_LEN) ? 0 : charValue * leftPos;
     }
 
     /**
@@ -100,7 +100,7 @@ public final class ECNumberCheckDigit extends ModulusCheckDigit {
             return false;
         }
         Object cde = REGEX_VALIDATOR.validate(code);
-        if(cde instanceof String) {
+        if (cde instanceof String) {
         	try {
         		final int modulusResult = calculateModulus((String)cde, true);
 //        		System.out.println("modulusResult="+modulusResult + " for code "+code);

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigit.java
@@ -36,7 +36,7 @@ import org.apache.commons.validator.routines.CodeValidator;
  *  <a href="https://en.wikipedia.org/wiki/European_Community_number">Wikipedia - EC number</a>.
  * </p>
  *
- * @since 1.9
+ * @since 1.9.0
  */
 public final class ECNumberCheckDigit extends ModulusCheckDigit {
 
@@ -87,7 +87,7 @@ public final class ECNumberCheckDigit extends ModulusCheckDigit {
         if (code == null || code.isEmpty()) {
             throw new CheckDigitException("Code is missing");
         }
-        final int modulusResult = calculateModulus(code, false);
+        int modulusResult = calculateModulus(code, false);
         return toCheckDigit(modulusResult);
     }
 
@@ -103,7 +103,6 @@ public final class ECNumberCheckDigit extends ModulusCheckDigit {
         if (cde instanceof String) {
             try {
                 final int modulusResult = calculateModulus((String)cde, true);
-//              System.out.println("modulusResult="+modulusResult + " for code "+code);
                 return modulusResult == Character.getNumericValue(code.charAt(code.length() - 1));
             } catch (final CheckDigitException ex) {
                 return false;

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigit.java
@@ -102,7 +102,7 @@ public final class ECNumberCheckDigit extends ModulusCheckDigit {
         Object cde = REGEX_VALIDATOR.validate(code);
         if (cde instanceof String) {
             try {
-        		final int modulusResult = calculateModulus((String)cde, true);
+        	    final int modulusResult = calculateModulus((String)cde, true);
 //        		System.out.println("modulusResult="+modulusResult + " for code "+code);
         		return modulusResult == Character.getNumericValue(code.charAt(code.length() - 1));
         	} catch (final CheckDigitException ex) {

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigit.java
@@ -101,7 +101,7 @@ public final class ECNumberCheckDigit extends ModulusCheckDigit {
         }
         Object cde = REGEX_VALIDATOR.validate(code);
         if (cde instanceof String) {
-        	try {
+            try {
         		final int modulusResult = calculateModulus((String)cde, true);
 //        		System.out.println("modulusResult="+modulusResult + " for code "+code);
         		return modulusResult == Character.getNumericValue(code.charAt(code.length() - 1));

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigit.java
@@ -42,7 +42,7 @@ public final class ECNumberCheckDigit extends ModulusCheckDigit {
 
     private static final long serialVersionUID = 7265356024784308367L;
 
-	/** Singleton Check Digit instance */
+    /** Singleton Check Digit instance */
     public static final CheckDigit EC_CHECK_DIGIT = new ECNumberCheckDigit();
 
     /**

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/ModulusCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/ModulusCheckDigit.java
@@ -187,12 +187,12 @@ public abstract class ModulusCheckDigit extends AbstractCheckDigit implements Se
 
     /**
      * A convenient method to check empty Strings.
-     *  
+     *
      * @param code The code to check
      * @return {@code true} if code is null or empty, otherwise {@code false}
      */
     protected boolean isEmpty(final String code) {
-    	return code == null || code.isEmpty();
+        return code == null || code.isEmpty();
     }
 
     /**

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/ModulusCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/ModulusCheckDigit.java
@@ -186,6 +186,16 @@ public abstract class ModulusCheckDigit extends AbstractCheckDigit implements Se
     }
 
     /**
+     * A convenient method to check empty Strings.
+     *  
+     * @param code The code to check
+     * @return {@code true} if code is null or empty, otherwise {@code false}
+     */
+    protected boolean isEmpty(final String code) {
+    	return code == null || code.isEmpty();
+    }
+
+    /**
      * Calculates the <i>weighted</i> value of a character in the
      * code at a specified position.
      * <p>

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/ModulusCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/ModulusCheckDigit.java
@@ -186,16 +186,6 @@ public abstract class ModulusCheckDigit extends AbstractCheckDigit implements Se
     }
 
     /**
-     * A convenient method to check empty Strings.
-     *
-     * @param code The code to check
-     * @return {@code true} if code is null or empty, otherwise {@code false}
-     */
-    protected boolean isEmpty(final String code) {
-        return code == null || code.isEmpty();
-    }
-
-    /**
      * Calculates the <i>weighted</i> value of a character in the
      * code at a specified position.
      * <p>

--- a/src/test/java/org/apache/commons/validator/routines/checkdigit/AbstractCheckDigitTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/checkdigit/AbstractCheckDigitTest.java
@@ -35,7 +35,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 
 /**
- * Luhn Check Digit Test.
+ * Check Digit Test.
  */
 public abstract class AbstractCheckDigitTest {
 
@@ -155,9 +155,8 @@ public abstract class AbstractCheckDigitTest {
                 }
                 final String expected = checkDigit(code);
                 String codeWithNoCheckDigit = removeCheckDigit(code);
-                if(codeWithNoCheckDigit==null) {
-                	//System.out.println("   " + "Invalid Code=[" + code + "]");
-                	throw new CheckDigitException("Invalid Code=[" + code + "]");
+                if (codeWithNoCheckDigit == null) {
+                    throw new CheckDigitException("Invalid Code=[" + code + "]");
                 }
                 final String actual = routine.calculate(codeWithNoCheckDigit);
                 // If exception not thrown, check that the digit is incorrect instead

--- a/src/test/java/org/apache/commons/validator/routines/checkdigit/AbstractCheckDigitTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/checkdigit/AbstractCheckDigitTest.java
@@ -154,7 +154,12 @@ public abstract class AbstractCheckDigitTest {
                     log.debug("   " + i + " Testing Invalid Check Digit, Code=[" + code + "]");
                 }
                 final String expected = checkDigit(code);
-                final String actual = routine.calculate(removeCheckDigit(code));
+                String codeWithNoCheckDigit = removeCheckDigit(code);
+                if(codeWithNoCheckDigit==null) {
+                	//System.out.println("   " + "Invalid Code=[" + code + "]");
+                	throw new CheckDigitException("Invalid Code=[" + code + "]");
+                }
+                final String actual = routine.calculate(codeWithNoCheckDigit);
                 // If exception not thrown, check that the digit is incorrect instead
                 if (expected.equals(actual)) {
                     fail("Expected mismatch for " + code + " expected " + expected + " actual " + actual);

--- a/src/test/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigitTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigitTest.java
@@ -37,7 +37,7 @@ public class CASNumberCheckDigitTest extends AbstractCheckDigitTest {
      */
     @BeforeEach
     protected void setUp() {
-        routine = CASNumberCheckDigit.CAS_CHECK_DIGIT;
+        routine = CASNumberCheckDigit.getInstance();
         valid = new String[] {WATER, ETHANOL, ASPIRIN, COFFEIN, FORMALDEHYDE, DEXAMETHASONE, ARSENIC, ASBESTOS };
     }
 

--- a/src/test/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigitTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigitTest.java
@@ -19,7 +19,7 @@ package org.apache.commons.validator.routines.checkdigit;
 import org.junit.jupiter.api.BeforeEach;
 
 /**
- * CAS Number Check Digit Test.
+ * CAS Number Check Digit Tests.
  */
 public class CASNumberCheckDigitTest extends AbstractCheckDigitTest {
 

--- a/src/test/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigitTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigitTest.java
@@ -27,9 +27,10 @@ public class CASNumberCheckDigitTest extends AbstractCheckDigitTest {
     private static final String ETHANOL = "64-17-5";
     private static final String ASPIRIN = "50-78-2";
     private static final String COFFEIN = "58-08-2";
-    private static final String D_METHIONIN = "348-67-4";
-    private static final String L_METHIONIN = "63-68-3";
-    private static final String DL_METHIONIN = "59-51-8";
+    private static final String FORMALDEHYDE = "50-00-0";
+    private static final String DEXAMETHASONE = "50-02-2";
+    private static final String ARSENIC = "7440-38-2";
+    private static final String ASBESTOS = "1332-21-4";
     
     /**
      * Sets up routine & valid codes.
@@ -37,7 +38,7 @@ public class CASNumberCheckDigitTest extends AbstractCheckDigitTest {
     @BeforeEach
     protected void setUp() {
         routine = CASNumberCheckDigit.CAS_CHECK_DIGIT;
-        valid = new String[] { WATER, ETHANOL, ASPIRIN, COFFEIN, D_METHIONIN, L_METHIONIN, DL_METHIONIN};
+        valid = new String[] {WATER, ETHANOL, ASPIRIN, COFFEIN, FORMALDEHYDE, DEXAMETHASONE, ARSENIC, ASBESTOS };
     }
 
     /**

--- a/src/test/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigitTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigitTest.java
@@ -31,7 +31,7 @@ public class CASNumberCheckDigitTest extends AbstractCheckDigitTest {
     private static final String DEXAMETHASONE = "50-02-2";
     private static final String ARSENIC = "7440-38-2";
     private static final String ASBESTOS = "1332-21-4";
-    
+
     /**
      * Sets up routine & valid codes.
      */
@@ -46,11 +46,11 @@ public class CASNumberCheckDigitTest extends AbstractCheckDigitTest {
      */
     @Override
     protected String removeCheckDigit(final String code) {
-        String cde = (String)CASNumberCheckDigit.REGEX_VALIDATOR.validate(code);
+        String cde = (String) CASNumberCheckDigit.REGEX_VALIDATOR.validate(code);
         if (cde == null || cde.length() <= checkDigitLth) {
             return null;
         }
         return cde.substring(0, cde.length() - checkDigitLth);
     }
-    
+
 }

--- a/src/test/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigitTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigitTest.java
@@ -46,9 +46,11 @@ public class CASNumberCheckDigitTest extends AbstractCheckDigitTest {
      */
     @Override
     protected String removeCheckDigit(final String code) {
-    	String cde = (String)CASNumberCheckDigit.REGEX_VALIDATOR.validate(code);
-    	if(cde == null || cde.length() <= checkDigitLth) return null;
-    	return cde.substring(0, cde.length() - checkDigitLth);
+        String cde = (String)CASNumberCheckDigit.REGEX_VALIDATOR.validate(code);
+        if (cde == null || cde.length() <= checkDigitLth) {
+            return null;
+        }
+        return cde.substring(0, cde.length() - checkDigitLth);
     }
     
 }

--- a/src/test/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigitTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigitTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.BeforeEach;
  */
 public class CASNumberCheckDigitTest extends AbstractCheckDigitTest {
 
+    private static final String MIN = "00-01-1"; // theoretical
     private static final String WATER = "7732-18-5";
     private static final String ETHANOL = "64-17-5";
     private static final String ASPIRIN = "50-78-2";
@@ -31,6 +32,7 @@ public class CASNumberCheckDigitTest extends AbstractCheckDigitTest {
     private static final String DEXAMETHASONE = "50-02-2";
     private static final String ARSENIC = "7440-38-2";
     private static final String ASBESTOS = "1332-21-4";
+    private static final String MAX = "9999999-99-5"; // theoretical
 
     /**
      * Sets up routine & valid codes.
@@ -38,7 +40,7 @@ public class CASNumberCheckDigitTest extends AbstractCheckDigitTest {
     @BeforeEach
     protected void setUp() {
         routine = CASNumberCheckDigit.getInstance();
-        valid = new String[] {WATER, ETHANOL, ASPIRIN, COFFEIN, FORMALDEHYDE, DEXAMETHASONE, ARSENIC, ASBESTOS };
+        valid = new String[] {MIN, WATER, ETHANOL, ASPIRIN, COFFEIN, FORMALDEHYDE, DEXAMETHASONE, ARSENIC, ASBESTOS, MAX};
     }
 
     /**

--- a/src/test/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigitTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigitTest.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.validator.routines.checkdigit;
+
+import org.junit.jupiter.api.BeforeEach;
+
+/**
+ * CAS Number Check Digit Test.
+ */
+public class CASNumberCheckDigitTest extends AbstractCheckDigitTest {
+
+    private static final String WATER = "7732-18-5";
+    private static final String ETHANOL = "64-17-5";
+    private static final String ASPIRIN = "50-78-2";
+    private static final String COFFEIN = "58-08-2";
+    private static final String D_METHIONIN = "348-67-4";
+    private static final String L_METHIONIN = "63-68-3";
+    private static final String DL_METHIONIN = "59-51-8";
+    
+    /**
+     * Sets up routine & valid codes.
+     */
+    @BeforeEach
+    protected void setUp() {
+        routine = CASNumberCheckDigit.CAS_CHECK_DIGIT;
+        valid = new String[] { WATER, ETHANOL, ASPIRIN, COFFEIN, D_METHIONIN, L_METHIONIN, DL_METHIONIN};
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected String removeCheckDigit(final String code) {
+    	String cde = (String)CASNumberCheckDigit.REGEX_VALIDATOR.validate(code);
+    	if(cde == null || cde.length() <= checkDigitLth) return null;
+    	return cde.substring(0, cde.length() - checkDigitLth);
+    }
+    
+}

--- a/src/test/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigitTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigitTest.java
@@ -19,7 +19,7 @@ package org.apache.commons.validator.routines.checkdigit;
 import org.junit.jupiter.api.BeforeEach;
 
 /**
- * EC Number Check Digit Test.
+ * EC Number Check Digit Tests.
  */
 public class ECNumberCheckDigitTest extends AbstractCheckDigitTest {
 

--- a/src/test/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigitTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigitTest.java
@@ -27,7 +27,7 @@ public class ECNumberCheckDigitTest extends AbstractCheckDigitTest {
     private static final String DEXAMETHASONE = "200-003-9";
     private static final String ARSENIC = "231-148-6";
     private static final String ASBESTOS = "603-721-4";
-    
+
     /**
      * Sets up routine & valid codes.
      */
@@ -42,11 +42,11 @@ public class ECNumberCheckDigitTest extends AbstractCheckDigitTest {
      */
     @Override
     protected String removeCheckDigit(final String code) {
-        String cde = (String)ECNumberCheckDigit.REGEX_VALIDATOR.validate(code);
+        String cde = (String) ECNumberCheckDigit.REGEX_VALIDATOR.validate(code);
         if (cde == null || cde.length() <= checkDigitLth) {
             return null;
         }
         return cde.substring(0, cde.length() - checkDigitLth);
     }
-    
+
 }

--- a/src/test/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigitTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigitTest.java
@@ -42,9 +42,11 @@ public class ECNumberCheckDigitTest extends AbstractCheckDigitTest {
      */
     @Override
     protected String removeCheckDigit(final String code) {
-    	String cde = (String)ECNumberCheckDigit.REGEX_VALIDATOR.validate(code);
-    	if(cde == null || cde.length() <= checkDigitLth) return null;
-    	return cde.substring(0, cde.length() - checkDigitLth);
+        String cde = (String)ECNumberCheckDigit.REGEX_VALIDATOR.validate(code);
+        if (cde == null || cde.length() <= checkDigitLth) {
+            return null;
+        }
+        return cde.substring(0, cde.length() - checkDigitLth);
     }
     
 }

--- a/src/test/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigitTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigitTest.java
@@ -33,7 +33,7 @@ public class ECNumberCheckDigitTest extends AbstractCheckDigitTest {
      */
     @BeforeEach
     protected void setUp() {
-        routine = ECNumberCheckDigit.EC_CHECK_DIGIT;
+        routine = ECNumberCheckDigit.getInstance();
         valid = new String[] { FORMALDEHYDE, DEXAMETHASONE, ARSENIC, ASBESTOS };
     }
 

--- a/src/test/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigitTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigitTest.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.validator.routines.checkdigit;
+
+import org.junit.jupiter.api.BeforeEach;
+
+/**
+ * EC Number Check Digit Test.
+ */
+public class ECNumberCheckDigitTest extends AbstractCheckDigitTest {
+
+    private static final String FORMALDEHYDE = "200-001-8";
+    private static final String DEXAMETHASONE = "200-003-9";
+    private static final String ARSENIC = "231-148-6";
+    private static final String ASBESTOS = "603-721-4";
+    
+    /**
+     * Sets up routine & valid codes.
+     */
+    @BeforeEach
+    protected void setUp() {
+        routine = ECNumberCheckDigit.EC_CHECK_DIGIT;
+        valid = new String[] { FORMALDEHYDE, DEXAMETHASONE, ARSENIC, ASBESTOS };
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    protected String removeCheckDigit(final String code) {
+    	String cde = (String)ECNumberCheckDigit.REGEX_VALIDATOR.validate(code);
+    	if(cde == null || cde.length() <= checkDigitLth) return null;
+    	return cde.substring(0, cde.length() - checkDigitLth);
+    }
+    
+}

--- a/src/test/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigitTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigitTest.java
@@ -23,10 +23,12 @@ import org.junit.jupiter.api.BeforeEach;
  */
 public class ECNumberCheckDigitTest extends AbstractCheckDigitTest {
 
-    private static final String FORMALDEHYDE = "200-001-8";
+    private static final String MIN = "000-001-6"; // theoretical
+    private static final String FORMALDEHYDE = "200-001-8"; // this is the first entry in EINECS
     private static final String DEXAMETHASONE = "200-003-9";
     private static final String ARSENIC = "231-148-6";
     private static final String ASBESTOS = "603-721-4";
+    private static final String MAX = "999-999-2"; // theoretical
 
     /**
      * Sets up routine & valid codes.
@@ -34,7 +36,7 @@ public class ECNumberCheckDigitTest extends AbstractCheckDigitTest {
     @BeforeEach
     protected void setUp() {
         routine = ECNumberCheckDigit.getInstance();
-        valid = new String[] { FORMALDEHYDE, DEXAMETHASONE, ARSENIC, ASBESTOS };
+        valid = new String[] {MIN, FORMALDEHYDE, DEXAMETHASONE, ARSENIC, ASBESTOS, MAX};
     }
 
     /**


### PR DESCRIPTION
Hi @garydgregory 
I incidently closed PR #216 - so I open a new one.  Your hints from yesterday are done with last two commits. 

Same description:

CASNumberCheckDigit - CAS Chemical Abstracts Service RN Registry No

CAS Numbers are unique identification numbers used to identify chemical
substance described in the open scientific literature.

see [wikipedia CAS_Registry_Number](https://en.wikipedia.org/wiki/CAS_Registry_Number)

Also add Validator for EC number - ECN is a unique seven-digit identifier that is assigned to chemical substances

regards