### PR TITLE
change CASNumberCheckDigit and ECNumberCheckDigit, add ECIndexNumberValidator

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/CASNumberValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/CASNumberValidator.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.validator.routines;
+
+import java.io.Serializable;
+
+import org.apache.commons.validator.routines.checkdigit.CASNumberCheckDigit;
+
+/**
+ * <b>CAS Registry Number</b> (or <b>Chemical Abstracts Service</b> (CAS RN)) validation.
+ *
+ * <p>
+ * CAS Numbers are unique identification numbers used
+ * to identify chemical substance described in the open scientific literature.
+ * </p>
+ *
+ * <p>
+ * Check digit calculation is based on <i>modulus 10</i> with digits being weighted
+ * based on their position (from right to left).
+ * </p>
+ *
+ * <p>
+ * For further information see
+ *  <a href="https://en.wikipedia.org/wiki/CAS_Registry_Number">Wikipedia - CAS Registry Number</a>.
+ * </p>
+ *
+ * @since 1.9.0
+ */
+public final class CASNumberValidator implements Serializable {
+
+    private static final long serialVersionUID = -5750098586109080748L;
+
+	/** Singleton instance */
+    private static final CASNumberValidator INSTANCE = new CASNumberValidator();
+
+    /**
+     * Gets the singleton instance of this validator.
+     * @return A singleton instance of the CAS Number validator.
+     */
+    public static CASNumberValidator getInstance() {
+        return INSTANCE;
+    }
+
+    private static final String GROUP1 = "([1-9]\\d{1,6})";
+    private static final String DASH = "(?:\\-)";
+
+    /**
+     * CAS number consists of 3 groups of numbers separated dashes (-).
+     * First group has 2 to 7 digits.
+     * Example: water is 7732-18-5
+     */
+    static final String CAS_REGEX = "^(?:" + GROUP1 + DASH + "(\\d{2})" + DASH + "(\\d))$";
+
+    static final CodeValidator VALIDATOR = new CodeValidator(CAS_REGEX, 
+        CASNumberCheckDigit.MIN_LEN, CASNumberCheckDigit.MAX_LEN, 
+        CASNumberCheckDigit.getInstance());
+
+    /**
+     * Constructs a validator.
+     */
+    private CASNumberValidator() { }
+
+    /**
+     * Tests whether the code is a valid CAS number.
+     *
+     * @param code The code to validate.
+     * @return {@code true} if a CAS number, otherwise {@code false}.
+     */
+    public boolean isValid(final String code) {
+        return VALIDATOR.isValid(code);
+    }
+
+    /**
+     * Checks the code is valid CAS number.
+     *
+     * @param code The code to validate.
+     * @return A CAS number code with dashes removed if valid, otherwise {@code null}.
+     */
+    public Object validate(final String code) {
+        final Object validate = VALIDATOR.validate(code);
+        if (validate != null) {
+            return VALIDATOR.isValid(code) ? validate : null;
+        }
+        return validate;
+    }
+
+}

--- a/src/main/java/org/apache/commons/validator/routines/CASNumberValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/CASNumberValidator.java
@@ -44,7 +44,7 @@ public final class CASNumberValidator implements Serializable {
 
     private static final long serialVersionUID = -5750098586109080748L;
 
-	/** Singleton instance */
+    /** Singleton instance */
     private static final CASNumberValidator INSTANCE = new CASNumberValidator();
 
     /**
@@ -65,8 +65,8 @@ public final class CASNumberValidator implements Serializable {
      */
     static final String CAS_REGEX = "^(?:" + GROUP1 + DASH + "(\\d{2})" + DASH + "(\\d))$";
 
-    static final CodeValidator VALIDATOR = new CodeValidator(CAS_REGEX, 
-        CASNumberCheckDigit.MIN_LEN, CASNumberCheckDigit.MAX_LEN, 
+    static final CodeValidator VALIDATOR = new CodeValidator(CAS_REGEX,
+        CASNumberCheckDigit.MIN_LEN, CASNumberCheckDigit.MAX_LEN,
         CASNumberCheckDigit.getInstance());
 
     /**

--- a/src/main/java/org/apache/commons/validator/routines/ECIndexNumberValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/ECIndexNumberValidator.java
@@ -32,7 +32,7 @@ import org.apache.commons.validator.routines.checkdigit.ECIndexNumberCheckDigit;
  *
  * <p>
  * The Index number for each substance is in the form of a digit sequence of the type
- * <code>ABC-RST-VW-Y</code>. 
+ * <code>ABC-RST-VW-Y</code>.
  * <br>
  * <code>ABC</code> corresponds to the atomic number of the most characteristic element
  * or the most characteristic organic group in the molecule.
@@ -76,7 +76,7 @@ public final class ECIndexNumberValidator implements Serializable {
      */
     static final String ECI_REGEX = "^(?:" + GROUP + DASH + GROUP + DASH + "(\\d{2})" + DASH + "([0-9X]))$";
 
-    static final CodeValidator VALIDATOR = new CodeValidator(ECI_REGEX, ECIndexNumberCheckDigit.LEN, 
+    static final CodeValidator VALIDATOR = new CodeValidator(ECI_REGEX, ECIndexNumberCheckDigit.LEN,
         ECIndexNumberCheckDigit.getInstance());
 
     /**

--- a/src/main/java/org/apache/commons/validator/routines/ECIndexNumberValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/ECIndexNumberValidator.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.validator.routines;
+
+import java.io.Serializable;
+
+import org.apache.commons.validator.routines.checkdigit.ECIndexNumberCheckDigit;
+
+/**
+ * <b>EC index number</b> validation.
+ *
+ * <p>
+ * The European Community index number is a unique nine-digit identifier
+ * that is assigned to hazardous chemical substances.
+ * <br>
+ * For example, the EC index number of lithium is <code>003-001-00-4</code>
+ * </p>
+ *
+ * <p>
+ * The Index number for each substance is in the form of a digit sequence of the type
+ * <code>ABC-RST-VW-Y</code>. 
+ * <br>
+ * <code>ABC</code> corresponds to the atomic number of the most characteristic element
+ * or the most characteristic organic group in the molecule.
+ * <br>
+ * <code>RST</code> is the consecutive number of the substance in the series <code>ABC</code>.
+ * <br>
+ * <code>VW</code> denotes the form in which the substance is produced or placed on the market.
+ * <br>
+ * <code>Y</code> is the check-digit. Check digit calculation is based on <i>modulus 11</i>
+ * with digits being weighted based on their position (from left to right).
+ * </p>
+ *
+ * <p>
+ * For further information see
+ *  <a href="https://eur-lex.europa.eu/eli/reg/2008/1272/oj?locale=en">CLP_Regulation - ANNEX VI 1.1.1.1.Index numbers</a>
+ * </p>
+ *
+ * @since 1.9.0
+ */
+public final class ECIndexNumberValidator implements Serializable {
+
+    private static final long serialVersionUID = 6434158079879082191L;
+
+    /** Singleton instance */
+    private static final ECIndexNumberValidator INSTANCE = new ECIndexNumberValidator();
+
+    /**
+     * Gets the singleton instance of this validator.
+     * @return A singleton instance of the EC Index Number validator.
+     */
+    public static ECIndexNumberValidator getInstance() {
+        return INSTANCE;
+    }
+
+    private static final String GROUP = "(\\d{3})";
+    private static final String DASH = "(?:\\-)";
+
+    /**
+     * EC index number consists of 3 groups of numbers and a check digit separated dashes (-).
+     * Example: lithium is 003-001-00-4, HCl is 017-002-01-X
+     */
+    static final String ECI_REGEX = "^(?:" + GROUP + DASH + GROUP + DASH + "(\\d{2})" + DASH + "([0-9X]))$";
+
+    static final CodeValidator VALIDATOR = new CodeValidator(ECI_REGEX, ECIndexNumberCheckDigit.LEN, 
+        ECIndexNumberCheckDigit.getInstance());
+
+    /**
+     * Constructs a validator.
+     */
+    private ECIndexNumberValidator() { }
+
+    /**
+     * Tests whether the code is a valid EC index number.
+     *
+     * @param code The code to validate.
+     * @return {@code true} if a EC index number, otherwise {@code false}.
+     */
+    public boolean isValid(final String code) {
+        return VALIDATOR.isValid(code);
+    }
+
+    /**
+     * Checks the code is valid EC index number.
+     *
+     * @param code The code to validate.
+     * @return An EC index number code with dashes removed if valid, otherwise {@code null}.
+     */
+    public Object validate(final String code) {
+        final Object validate = VALIDATOR.validate(code);
+        if (validate != null) {
+            return VALIDATOR.isValid(code) ? validate : null;
+        }
+        return validate;
+    }
+
+}

--- a/src/main/java/org/apache/commons/validator/routines/ECNumberValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/ECNumberValidator.java
@@ -45,7 +45,7 @@ public final class ECNumberValidator implements Serializable {
 
     private static final long serialVersionUID = 6676297914206256712L;
 
-	/** Singleton instance */
+    /** Singleton instance */
     private static final ECNumberValidator INSTANCE = new ECNumberValidator();
 
     /**

--- a/src/main/java/org/apache/commons/validator/routines/ECNumberValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/ECNumberValidator.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.validator.routines;
+
+import java.io.Serializable;
+
+import org.apache.commons.validator.routines.checkdigit.ECNumberCheckDigit;
+
+/**
+ * <b>EC number</b> validation.
+ *
+ * <p>
+ * The European Community number (EC number) is a unique seven-digit identifier
+ * that is assigned to chemical substances.
+ * For example, the EC number of arsenic is 231-148-6:
+ * </p>
+ *
+ * <p>
+ * Check digit calculation is based on <i>modulus 11</i> with digits being weighted
+ * based on their position (from left to right).
+ * </p>
+ *
+ * <p>
+ * For further information see
+ *  <a href="https://en.wikipedia.org/wiki/European_Community_number">Wikipedia - EC number</a>.
+ * </p>
+ *
+ * @since 1.9.0
+ */
+public final class ECNumberValidator implements Serializable {
+
+    private static final long serialVersionUID = 6676297914206256712L;
+
+	/** Singleton instance */
+    private static final ECNumberValidator INSTANCE = new ECNumberValidator();
+
+    /**
+     * Gets the singleton instance of this validator.
+     * @return A singleton instance of the EC Number validator.
+     */
+    public static ECNumberValidator getInstance() {
+        return INSTANCE;
+    }
+
+    private static final String GROUP1 = "([2-9]\\d{2})"; // EINECS numbers starts with 2xx-xxx-C
+    private static final String GROUP2 = "(\\d{3})";
+    private static final String DASH = "(?:\\-)";
+
+    /**
+     * EC number consists of 3 groups of numbers separated dashes (-).
+     * Example: dexamethasone is 200-003-9
+     */
+    static final String EC_REGEX = "^(?:" + GROUP1 + DASH + GROUP2 + DASH + "(\\d))$";
+
+    static final CodeValidator VALIDATOR = new CodeValidator(EC_REGEX, ECNumberCheckDigit.LEN, ECNumberCheckDigit.getInstance());
+
+    /**
+     * Constructs a validator.
+     */
+    private ECNumberValidator() { }
+
+    /**
+     * Tests whether the code is a valid EC number.
+     *
+     * @param code The code to validate.
+     * @return {@code true} if a EC number, otherwise {@code false}.
+     */
+    public boolean isValid(final String code) {
+        return VALIDATOR.isValid(code);
+    }
+
+    /**
+     * Checks the code is valid EC number.
+     *
+     * @param code The code to validate.
+     * @return An EC number code with dashes removed if valid, otherwise {@code null}.
+     */
+    public Object validate(final String code) {
+        final Object validate = VALIDATOR.validate(code);
+        if (validate != null) {
+            return VALIDATOR.isValid(code) ? validate : null;
+        }
+        return validate;
+    }
+
+}

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigit.java
@@ -17,7 +17,6 @@
 package org.apache.commons.validator.routines.checkdigit;
 
 import org.apache.commons.validator.GenericValidator;
-import org.apache.commons.validator.routines.CASNumberValidator;
 
 /**
  * Modulus 10 <b>CAS Registry Number</b> Check Digit calculation/validation.
@@ -103,8 +102,7 @@ public final class CASNumberCheckDigit extends ModulusCheckDigit {
         if (GenericValidator.isBlankOrNull(code)) {
             throw new CheckDigitException("Code is missing");
         }
-        int modulusResult = INSTANCE.calculateModulus(code, false);
-        return toCheckDigit(modulusResult);
+        return toCheckDigit(INSTANCE.calculateModulus(code, false));
     }
 
     /**

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigit.java
@@ -26,15 +26,15 @@ import org.apache.commons.validator.routines.CASNumberValidator;
  * CAS Registry Numbers are a numeric codes.
  * Check digit calculation is based on <i>modulus 10</i> with digits being weighted
  * based on their position (from right to left).
- * <br/>
+ * <br>
  * The check digit is found by taking the last digit times 1, the preceding digit times 2,
  * the preceding digit times 3 etc., adding all these up and computing the sum modulo 10.
- * <br/>
+ * <br>
  * For example, the CAS number of water is <code>7732-18-5</code>:
  * the checksum 5 is calculated as (8×1 + 1×2 + 2×3 + 3×4 + 7×5 + 7×6) = 105; 105 mod 10 = 5.
- * <br/>
+ * <br>
  * Note that these <b>do not validate</b> the input for syntax.
- * Such validation is performed by the {@link CASNumberValidator}
+ * Such validation is performed by the {@link org.apache.commons.validator.routines.CASNumberValidator}
  * </p>
  *
  * @since 1.9.0

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigit.java
@@ -17,32 +17,24 @@
 package org.apache.commons.validator.routines.checkdigit;
 
 import org.apache.commons.validator.GenericValidator;
-import org.apache.commons.validator.routines.CodeValidator;
+import org.apache.commons.validator.routines.CASNumberValidator;
 
 /**
- * Modulus 10 <b>CAS Registry Number</b> (or <b>Chemical Abstracts Service</b> (CAS RN)) Check Digit
- * calculation/validation.
+ * Modulus 10 <b>CAS Registry Number</b> Check Digit calculation/validation.
  *
  * <p>
- * CAS Numbers are unique identification numbers used
- * to identify chemical substance described in the open scientific literature.
- * </p>
- *
- * <p>
+ * CAS Registry Numbers are a numeric codes.
  * Check digit calculation is based on <i>modulus 10</i> with digits being weighted
  * based on their position (from right to left).
- * </p>
- *
- * <p>
+ * <br/>
  * The check digit is found by taking the last digit times 1, the preceding digit times 2,
  * the preceding digit times 3 etc., adding all these up and computing the sum modulo 10.
+ * <br/>
  * For example, the CAS number of water is <code>7732-18-5</code>:
  * the checksum 5 is calculated as (8×1 + 1×2 + 2×3 + 3×4 + 7×5 + 7×6) = 105; 105 mod 10 = 5.
- * </p>
- *
- * <p>
- * For further information see
- *  <a href="https://en.wikipedia.org/wiki/CAS_Registry_Number">Wikipedia - CAS Registry Number</a>.
+ * <br/>
+ * Note that these <b>do not validate</b> the input for syntax.
+ * Such validation is performed by the {@link CASNumberValidator}
  * </p>
  *
  * @since 1.9.0
@@ -63,18 +55,16 @@ public final class CASNumberCheckDigit extends ModulusCheckDigit {
     }
 
     /**
+     * The minimum length without dashes.
+     * <p>
      * CAS number consists of 3 groups of numbers separated dashes (-).
-     * First group has 2 to 7 digits.
+     * First group has 2 to 7 digits, the second 2 digits, the third is the check digit.
      * Example: water is 7732-18-5
+     * </p>
      */
-    private static final String GROUP1 = "(\\d{2,7})";
-    private static final String DASH = "(?:\\-)";
-    static final String CAS_REGEX = "^(?:" + GROUP1 + DASH + "(\\d{2})" + DASH + "(\\d))$";
-
-    private static final int CAS_MIN_LEN = 4; // 9-99-9 LEN without SEP
-    /** maximum capacity of 1,000,000,000 == 9999999-99-9*/
-    private static final int CAS_MAX_LEN = 10;
-    static final CodeValidator REGEX_VALIDATOR = new CodeValidator(CAS_REGEX, CAS_MIN_LEN, CAS_MAX_LEN, null);
+    public static final int MIN_LEN = 5; // 10-00-4 LEN without SEP
+    /** The maximum length without dashes. {@code 9999999-99-5} */
+    public static final int MAX_LEN = 10;
 
     /** Weighting given to digits depending on their right position */
     private static final int[] POSITION_WEIGHT = { 0, 1, 2, 3, 4, 5, 6, 7, 8, 9 };
@@ -82,8 +72,7 @@ public final class CASNumberCheckDigit extends ModulusCheckDigit {
     /**
      * Constructs a modulus 10 Check Digit routine for CAS Numbers.
      */
-    private CASNumberCheckDigit() {
-    }
+    private CASNumberCheckDigit() { }
 
     /**
      * Calculates the <i>weighted</i> value of a character in the code at a specified position.
@@ -126,15 +115,13 @@ public final class CASNumberCheckDigit extends ModulusCheckDigit {
         if (GenericValidator.isBlankOrNull(code)) {
             return false;
         }
-        Object cde = REGEX_VALIDATOR.validate(code);
-        if (cde instanceof String) {
-            try {
-                final int modulusResult = INSTANCE.calculateModulus((String) cde, true);
-                return modulusResult == Character.getNumericValue(code.charAt(code.length() - 1));
-            } catch (final CheckDigitException ex) {
-                return false;
-            }
-        } else {
+        if (code.length() < MIN_LEN || code.length() > MAX_LEN) {
+            return false;
+        }
+        try {
+            final int modulusResult = INSTANCE.calculateModulus(code, true);
+            return modulusResult == Character.getNumericValue(code.charAt(code.length() - 1));
+        } catch (final CheckDigitException ex) {
             return false;
         }
     }

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/ECIndexNumberCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/ECIndexNumberCheckDigit.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.validator.routines.checkdigit;
+
+import org.apache.commons.validator.GenericValidator;
+import org.apache.commons.validator.routines.ECIndexNumberValidator;
+
+/**
+ * Modulus 11 <b>EC index number</b> Check Digit calculation/validation.
+ *
+ * <p>
+ * EC Index Numbers are a numeric code except for the last (check) digit
+ * which can have a value of "X".
+ * <br>
+ * Note that these <b>do not validate</b> the input for syntax.
+ * Such validation is performed by the {@link ECIndexNumberValidator}
+ * </p>
+ *
+ * @since 1.9.0
+ */
+public final class ECIndexNumberCheckDigit extends ModulusCheckXDigit {
+
+    private static final long serialVersionUID = 2078815937513115949L;
+
+    /** Singleton Check Digit instance */
+    private static final ECIndexNumberCheckDigit INSTANCE = new ECIndexNumberCheckDigit();
+
+    /**
+     * Gets the singleton instance of this validator.
+     * @return A singleton instance of the EC Index Number validator.
+     */
+    public static CheckDigit getInstance() {
+        return INSTANCE;
+    }
+
+    /**
+     * EC index number consists of 4 groups of nine numbers separated by dashes (-).
+     * Example: lithium is 003-001-00-4
+     * The length without dashes.
+     */
+    public static final int LEN = 9;
+
+    /**
+     * Constructs a modulus 11 Check Digit routine.
+     */
+    private ECIndexNumberCheckDigit() {
+        super();
+    }
+
+    /**
+     * Calculates the <i>weighted</i> value of a character in the
+     * code at a specified position.
+     *
+     * <p>For EC index number digits are weighted by their position from left to right.</p>
+     *
+     * @param charValue The numeric value of the character.
+     * @param leftPos The position of the character in the code, counting from left to right
+     * @param rightPos The positionof the character in the code, counting from right to left
+     * @return The weighted value of the character.
+     */
+    @Override
+    protected int weightedValue(final int charValue, final int leftPos, final int rightPos) {
+        return leftPos >= LEN ? 0 : charValue * leftPos;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String calculate(final String code) throws CheckDigitException {
+        if (GenericValidator.isBlankOrNull(code)) {
+            throw new CheckDigitException("Code is missing");
+        }
+        int modulusResult = INSTANCE.calculateModulus(code, false);
+        return toCheckDigit(modulusResult);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean isValid(final String code) {
+        if (GenericValidator.isBlankOrNull(code)) {
+            return false;
+        }
+        if (code.length() != LEN) {
+            return false;
+        }
+        try {
+            final int modulusResult = INSTANCE.calculateModulus(code, true);
+            return toCheckDigit(modulusResult).equals(code.substring(code.length() - 1));
+        } catch (final CheckDigitException ex) {
+            return false;
+        }
+    }
+
+}

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigit.java
@@ -17,25 +17,17 @@
 package org.apache.commons.validator.routines.checkdigit;
 
 import org.apache.commons.validator.GenericValidator;
-import org.apache.commons.validator.routines.CodeValidator;
 
 /**
  * Modulus 11 <b>EC number</b> Check Digit calculation/validation.
  *
  * <p>
- * The European Community number (EC number) is a unique seven-digit identifier
- * that is assigned to chemical substances.
- * For example, the EC number of arsenic is 231-148-6:
- * </p>
- *
- * <p>
+ * EC Numbers are a numeric codes.
  * Check digit calculation is based on <i>modulus 11</i> with digits being weighted
  * based on their position (from left to right).
- * </p>
- *
- * <p>
- * For further information see
- *  <a href="https://en.wikipedia.org/wiki/European_Community_number">Wikipedia - EC number</a>.
+ * <br/>
+ * Note that these <b>do not validate</b> the input for syntax.
+ * Such validation is performed by the {@link ECNumberValidator}
  * </p>
  *
  * @since 1.9.0
@@ -58,13 +50,9 @@ public final class ECNumberCheckDigit extends ModulusCheckDigit {
     /**
      * EC number consists of 3 groups of numbers separated dashes (-).
      * Example: dexamethasone is 200-003-9
+     * The length without dashes.
      */
-    private static final String GROUP = "(\\d{3})";
-    private static final String DASH = "(?:\\-)";
-    static final String EC_REGEX = "^(?:" + GROUP + DASH + GROUP + DASH + "(\\d))$";
-
-    private static final int EC_LEN = 7;
-    static final CodeValidator REGEX_VALIDATOR = new CodeValidator(EC_REGEX, EC_LEN, null);
+    public static final int LEN = 7;
 
     /**
      * Constructs a modulus 11 Check Digit routine.
@@ -86,7 +74,7 @@ public final class ECNumberCheckDigit extends ModulusCheckDigit {
      */
     @Override
     protected int weightedValue(final int charValue, final int leftPos, final int rightPos) {
-        return leftPos >= EC_LEN ? 0 : charValue * leftPos;
+        return leftPos >= LEN ? 0 : charValue * leftPos;
     }
 
     /**
@@ -109,15 +97,13 @@ public final class ECNumberCheckDigit extends ModulusCheckDigit {
         if (GenericValidator.isBlankOrNull(code)) {
             return false;
         }
-        Object cde = REGEX_VALIDATOR.validate(code);
-        if (cde instanceof String) {
-            try {
-                final int modulusResult = INSTANCE.calculateModulus((String) cde, true);
-                return modulusResult == Character.getNumericValue(code.charAt(code.length() - 1));
-            } catch (final CheckDigitException ex) {
-                return false;
-            }
-        } else {
+        if (code.length() != LEN) {
+            return false;
+        }
+        try {
+            final int modulusResult = INSTANCE.calculateModulus(code, true);
+            return modulusResult == Character.getNumericValue(code.charAt(code.length() - 1));
+        } catch (final CheckDigitException ex) {
             return false;
         }
     }

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigit.java
@@ -25,9 +25,9 @@ import org.apache.commons.validator.GenericValidator;
  * EC Numbers are a numeric codes.
  * Check digit calculation is based on <i>modulus 11</i> with digits being weighted
  * based on their position (from left to right).
- * <br/>
+ * <br>
  * Note that these <b>do not validate</b> the input for syntax.
- * Such validation is performed by the {@link ECNumberValidator}
+ * Such validation is performed by the {@link org.apache.commons.validator.routines.ECNumberValidator}
  * </p>
  *
  * @since 1.9.0

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigit.java
@@ -85,8 +85,7 @@ public final class ECNumberCheckDigit extends ModulusCheckDigit {
         if (GenericValidator.isBlankOrNull(code)) {
             throw new CheckDigitException("Code is missing");
         }
-        int modulusResult = INSTANCE.calculateModulus(code, false);
-        return toCheckDigit(modulusResult);
+        return toCheckDigit(INSTANCE.calculateModulus(code, false));
     }
 
     /**

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/ISBN10CheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/ISBN10CheckDigit.java
@@ -41,7 +41,7 @@ package org.apache.commons.validator.routines.checkdigit;
  *
  * @since 1.4
  */
-public final class ISBN10CheckDigit extends ModulusCheckDigit {
+public final class ISBN10CheckDigit extends ModulusCheckXDigit {
 
     private static final long serialVersionUID = 8000855044504864964L;
 
@@ -52,46 +52,7 @@ public final class ISBN10CheckDigit extends ModulusCheckDigit {
      * Constructs a modulus 11 Check Digit routine for ISBN-10.
      */
     public ISBN10CheckDigit() {
-        super(MODULUS_11);
-    }
-
-    /**
-     * <p>Convert an integer value to a character at a specified position.</p>
-     *
-     * <p>Value '10' for position 1 (check digit) converted to 'X'.</p>
-     *
-     * @param charValue The integer value of the character.
-     * @return The converted character.
-     * @throws CheckDigitException if an error occurs.
-     */
-    @Override
-    protected String toCheckDigit(final int charValue)
-            throws CheckDigitException {
-        if (charValue == 10) {  // CHECKSTYLE IGNORE MagicNumber
-            return "X";
-        }
-        return super.toCheckDigit(charValue);
-    }
-
-    /**
-     * <p>Convert a character at a specified position to an
-     * integer value.</p>
-     *
-     * <p>Character 'X' check digit converted to 10.</p>
-     *
-     * @param character The character to convert.
-     * @param leftPos The position of the character in the code, counting from left to right
-     * @param rightPos The position of the character in the code, counting from right to left
-     * @return The integer value of the character.
-     * @throws CheckDigitException if an error occurs.
-     */
-    @Override
-    protected int toInt(final char character, final int leftPos, final int rightPos)
-            throws CheckDigitException {
-        if (rightPos == 1 && character == 'X') {
-            return 10;  // CHECKSTYLE IGNORE MagicNumber
-        }
-        return super.toInt(character, leftPos, rightPos);
+        super();
     }
 
     /**

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/ISSNCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/ISSNCheckDigit.java
@@ -46,7 +46,7 @@ package org.apache.commons.validator.routines.checkdigit;
  * </pre>
  * @since 1.5.0
  */
-public final class ISSNCheckDigit extends ModulusCheckDigit {
+public final class ISSNCheckDigit extends ModulusCheckXDigit {
 
     private static final long serialVersionUID = 1L;
 
@@ -57,24 +57,7 @@ public final class ISSNCheckDigit extends ModulusCheckDigit {
      * Creates the instance using a checkdigit modulus of 11.
      */
     public ISSNCheckDigit() {
-        super(MODULUS_11);
-    }
-
-    @Override
-    protected String toCheckDigit(final int charValue) throws CheckDigitException {
-        if (charValue == 10) { // CHECKSTYLE IGNORE MagicNumber
-            return "X";
-        }
-        return super.toCheckDigit(charValue);
-    }
-
-    @Override
-    protected int toInt(final char character, final int leftPos, final int rightPos)
-            throws CheckDigitException {
-        if (rightPos == 1 && character == 'X') {
-            return 10; // CHECKSTYLE IGNORE MagicNumber
-        }
-        return super.toInt(character, leftPos, rightPos);
+        super();
     }
 
     @Override

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/ModulusCheckXDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/ModulusCheckXDigit.java
@@ -24,7 +24,7 @@ package org.apache.commons.validator.routines.checkdigit;
  * <p>
  * This implementation handles <i>single-digit numeric</i> codes
  * except for the last (check) digit which can have a value of "X",
- * such as <b>ISSN</b> or {@link ECIndexNumberValidator}.
+ * such as <b>ISSN</b> or <b>ECIndexNumberValidator</b>.
  * </p>
  *
  * @since 1.9.0

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/ModulusCheckXDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/ModulusCheckXDigit.java
@@ -22,8 +22,8 @@ package org.apache.commons.validator.routines.checkdigit;
  * Provides a <i>base</i> class for building <i>modulus 11</i> Check Digit routines.
  * </p>
  * <p>
- * This implementation handles <i>single-digit numeric</i> codes 
- * except for the last (check) digit which can have a value of "X", 
+ * This implementation handles <i>single-digit numeric</i> codes
+ * except for the last (check) digit which can have a value of "X",
  * such as <b>ISSN</b> or {@link ECIndexNumberValidator}.
  * </p>
  *

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/ModulusCheckXDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/ModulusCheckXDigit.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.validator.routines.checkdigit;
+
+/**
+ * Abstract <b>Modulus 11</b> Check digit calculation/validation.
+ * <p>
+ * Provides a <i>base</i> class for building <i>modulus 11</i> Check Digit routines.
+ * </p>
+ * <p>
+ * This implementation handles <i>single-digit numeric</i> codes 
+ * except for the last (check) digit which can have a value of "X", 
+ * such as <b>ISSN</b> or {@link ECIndexNumberValidator}.
+ * </p>
+ *
+ * @since 1.9.0
+ */
+public abstract class ModulusCheckXDigit extends ModulusCheckDigit {
+
+    private static final long serialVersionUID = -713912580806785481L;
+
+    /**
+     * Constructs a modulus 11 {@link CheckDigit} routine for a specified modulus.
+     */
+    ModulusCheckXDigit() {
+        super(MODULUS_11);
+    }
+
+    /**
+     * <p>Convert an integer value to a character at a specified position.</p>
+     *
+     * <p>Value '10' for position 1 (check digit) converted to 'X'.</p>
+     *
+     * @param charValue The integer value of the character.
+     * @return The converted character.
+     * @throws CheckDigitException if an error occurs.
+     */
+    @Override
+    protected String toCheckDigit(final int charValue) throws CheckDigitException {
+        if (charValue == 10) {  // CHECKSTYLE IGNORE MagicNumber
+            return "X";
+        }
+        return super.toCheckDigit(charValue);
+    }
+
+    /**
+     * <p>Convert a character at a specified position to an integer value.</p>
+     *
+     * <p>Character 'X' check digit converted to 10.</p>
+     *
+     * @param character The character to convert.
+     * @param leftPos The position of the character in the code, counting from left to right
+     * @param rightPos The position of the character in the code, counting from right to left
+     * @return The integer value of the character.
+     * @throws CheckDigitException if an error occurs.
+     */
+    @Override
+    protected int toInt(final char character, final int leftPos, final int rightPos) throws CheckDigitException {
+        if (rightPos == 1 && character == 'X') {
+            return 10;  // CHECKSTYLE IGNORE MagicNumber
+        }
+        return super.toInt(character, leftPos, rightPos);
+    }
+
+}

--- a/src/test/java/org/apache/commons/validator/routines/CASNumberValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/CASNumberValidatorTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.validator.routines;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link CASNumberValidator}.
+ */
+public class CASNumberValidatorTest {
+
+    private static final CASNumberValidator VALIDATOR = CASNumberValidator.getInstance();
+
+    private static final String WATER = "7732-18-5";
+    private static final String ETHANOL = "64-17-5";
+    private static final String ASPIRIN = "50-78-2";
+    private static final String COFFEIN = "58-08-2";
+    private static final String FORMALDEHYDE = "50-00-0";
+    private static final String DEXAMETHASONE = "50-02-2";
+    private static final String ARSENIC = "7440-38-2";
+    /**
+     * There are different CAS numbers for asbestos:
+     * <br/><a href="https://commonchemistry.cas.org/detail?cas_rn=1332-21-4">cas_rn=1332-21-4</a>
+     * <br/>https://commonchemistry.cas.org/detail?cas_rn=132207-32-0 Chrysotile asbestos
+     * <br/>https://commonchemistry.cas.org/detail?cas_rn=12172-73-5  Amosite asbestos
+     * <br/>https://commonchemistry.cas.org/detail?cas_rn=77536-66-4  Actinolite asbestos
+     * <br/>https://commonchemistry.cas.org/detail?cas_rn=77536-68-6  Tremolite asbestos
+     * <br/>https://commonchemistry.cas.org/detail?cas_rn=77536-67-5  Anthophyllite asbestos
+     * <br/>https://commonchemistry.cas.org/detail?cas_rn=12001-28-4  Crocidolite asbestos
+     * <br/>https://commonchemistry.cas.org/detail?cas_rn=12001-29-5  Chrysotile
+     * <br/>and some deleted or replaced CAS RNs
+     */
+    private static final String ASBESTOS = "1332-21-4";
+
+    private final String[] validFormat = {
+            " 10-00-4 ", // theoretical minimum with spaces
+            WATER,
+            ETHANOL,
+            ASPIRIN,
+            COFFEIN,
+            FORMALDEHYDE, 
+            DEXAMETHASONE, 
+            ARSENIC, 
+            ASBESTOS,
+            "\t9999999-99-5\n", }; // theoretical maximum with white spaces (TAB and NL)
+
+    private final String[] invalidFormat = { null, "", // empty
+            "   ", // empty
+            "7732-18-V", // proper check digit is '5', see above
+            "0064-17-5", // leading zeros
+            "50-78-02",  // proper check digit is '2', see above
+            "58-08-0",   // proper check digit is '2', see above
+            "50-00-X",   // proper check digit is '0', see above
+            "7440-38.2", // no dash
+            "9999999-99-9", // proper check digit is '5', see above
+            "999999999999", // 
+    };
+
+    @Test
+    public void testInvalidFalse() {
+        for (final String f : invalidFormat) {
+            assertFalse(VALIDATOR.isValid(f), f);
+        }
+    }
+
+    @Test
+    public void testIsValidTrue() {
+        for (final String f : validFormat) {
+            assertTrue(VALIDATOR.isValid(f), f);
+        }
+    }
+
+    @Test
+    public void testValidate() {
+        for (final String f : validFormat) {
+            assertEquals(VALIDATOR.validate(f), f.replaceAll("\\-", "").trim());
+        }
+        for (final String f : invalidFormat) {
+            assertNull(VALIDATOR.validate(f));
+        }
+    }
+
+}

--- a/src/test/java/org/apache/commons/validator/routines/CASNumberValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/CASNumberValidatorTest.java
@@ -57,9 +57,9 @@ public class CASNumberValidatorTest {
             ETHANOL,
             ASPIRIN,
             COFFEIN,
-            FORMALDEHYDE, 
-            DEXAMETHASONE, 
-            ARSENIC, 
+            FORMALDEHYDE,
+            DEXAMETHASONE,
+            ARSENIC,
             ASBESTOS,
             "\t9999999-99-5\n", }; // theoretical maximum with white spaces (TAB and NL)
 
@@ -72,8 +72,7 @@ public class CASNumberValidatorTest {
             "50-00-X",   // proper check digit is '0', see above
             "7440-38.2", // no dash
             "9999999-99-9", // proper check digit is '5', see above
-            "999999999999", // 
-    };
+            "999999999999" };
 
     @Test
     public void testInvalidFalse() {

--- a/src/test/java/org/apache/commons/validator/routines/ECIndexNumberValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/ECIndexNumberValidatorTest.java
@@ -1,0 +1,79 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.validator.routines;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link ECIndexNumberValidator}.
+ */
+public class ECIndexNumberValidatorTest {
+
+    private static final ECIndexNumberValidator VALIDATOR = ECIndexNumberValidator.getInstance();
+
+    private final String[] validFormat = {
+            " 000-000-01-8 ", // theoretical minimum with spaces
+            "001-001-00-9", // hydrogen - the first entry
+            "003-001-00-4", // lithium
+            "017-002-01-X", // Hydrochloric acid, Salzsäure
+            "033-001-00-X", // arsenic - last anorganic entry
+            "607-310-00-0", // kresoxim-methyl - an organic entry
+            "650-013-00-6", // asbestos
+            "\t999-999-99-5\n", }; // theoretical maximum with white spaces (TAB and NL)
+
+    private final String[] invalidFormat = { null, "", // empty
+            "   ", // empty
+            "000-000-01-X", // proper check digit is '8', see above
+            "001-001-00-0", // proper check digit is '9', see above
+            "003-001-00-6", // proper check digit is '4', see above
+            "017-002-01-x", // proper check digit is 'X', see above
+            "033-001-00-10", // proper check digit is 'X', see above
+            "607-310-00-X", // proper check digit is '0', see above
+            "650-013-00_6", // no dash
+            "999-999-99-9", // proper check digit is '5', see above
+            "999999999999" };
+
+    @Test
+    public void testInvalidFalse() {
+        for (final String f : invalidFormat) {
+            assertFalse(VALIDATOR.isValid(f), f);
+        }
+    }
+
+    @Test
+    public void testIsValidTrue() {
+        for (final String f : validFormat) {
+            assertTrue(VALIDATOR.isValid(f), f);
+        }
+    }
+
+    @Test
+    public void testValidate() {
+        for (final String f : validFormat) {
+            assertEquals(VALIDATOR.validate(f), f.replaceAll("\\-", "").trim());
+        }
+        for (final String f : invalidFormat) {
+            assertNull(VALIDATOR.validate(f));
+        }
+    }
+
+}

--- a/src/test/java/org/apache/commons/validator/routines/ECNumberValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/ECNumberValidatorTest.java
@@ -37,11 +37,11 @@ public class ECNumberValidatorTest {
 
     private final String[] validFormat = {
             " 200-000-2 ", // theoretical EINECS minimum with spaces
-            FORMALDEHYDE, 
-            DEXAMETHASONE, 
-            ARSENIC, 
+            FORMALDEHYDE,
+            DEXAMETHASONE,
+            ARSENIC,
             ASBESTOS,
-            "\t999-999-2\n", }; // theoretical maximum with white spaces (TAB and NL)
+            "\t999-999-2\n" }; // theoretical maximum with white spaces (TAB and NL)
 
     private final String[] invalidFormat = { null, "", // empty
             "   ", // empty
@@ -51,8 +51,7 @@ public class ECNumberValidatorTest {
             "603-721-0", // proper check digit is '4', see above
             "603-721+4", // no dash
             "999-999-9", // proper check digit is '2', see above
-            "999999999", // 
-    };
+            "999999999" };
 
     @Test
     public void testInvalidFalse() {

--- a/src/test/java/org/apache/commons/validator/routines/ECNumberValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/ECNumberValidatorTest.java
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.validator.routines;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests {@link ECNumberValidator}.
+ */
+public class ECNumberValidatorTest {
+
+    private static final ECNumberValidator VALIDATOR = ECNumberValidator.getInstance();
+
+    private static final String FORMALDEHYDE = "200-001-8"; // this is the first entry in EINECS
+    private static final String DEXAMETHASONE = "200-003-9";
+    private static final String ARSENIC = "231-148-6";
+    private static final String ASBESTOS = "603-721-4";
+
+    private final String[] validFormat = {
+            " 200-000-2 ", // theoretical EINECS minimum with spaces
+            FORMALDEHYDE, 
+            DEXAMETHASONE, 
+            ARSENIC, 
+            ASBESTOS,
+            "\t999-999-2\n", }; // theoretical maximum with white spaces (TAB and NL)
+
+    private final String[] invalidFormat = { null, "", // empty
+            "   ", // empty
+            "200-001-2", // proper check digit is '8', see above
+            "200-003-X", // proper check digit is '9', see above
+            "231-148-6!", // proper check digit is '6', see above
+            "603-721-0", // proper check digit is '4', see above
+            "603-721+4", // no dash
+            "999-999-9", // proper check digit is '2', see above
+            "999999999", // 
+    };
+
+    @Test
+    public void testInvalidFalse() {
+        for (final String f : invalidFormat) {
+            assertFalse(VALIDATOR.isValid(f), f);
+        }
+    }
+
+    @Test
+    public void testIsValidTrue() {
+        for (final String f : validFormat) {
+            assertTrue(VALIDATOR.isValid(f), f);
+        }
+    }
+
+    @Test
+    public void testValidate() {
+        for (final String f : validFormat) {
+            assertEquals(VALIDATOR.validate(f), f.replaceAll("\\-", "").trim());
+        }
+        for (final String f : invalidFormat) {
+            assertNull(VALIDATOR.validate(f));
+        }
+    }
+
+}

--- a/src/test/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigitTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigitTest.java
@@ -23,16 +23,17 @@ import org.junit.jupiter.api.BeforeEach;
  */
 public class CASNumberCheckDigitTest extends AbstractCheckDigitTest {
 
-    private static final String MIN = "00-01-1"; // theoretical
-    private static final String WATER = "7732-18-5";
-    private static final String ETHANOL = "64-17-5";
-    private static final String ASPIRIN = "50-78-2";
-    private static final String COFFEIN = "58-08-2";
-    private static final String FORMALDEHYDE = "50-00-0";
-    private static final String DEXAMETHASONE = "50-02-2";
-    private static final String ARSENIC = "7440-38-2";
-    private static final String ASBESTOS = "1332-21-4";
-    private static final String MAX = "9999999-99-5"; // theoretical
+	// valid CAS Number with dashes removed
+    private static final String MIN = "10004"; // theoretical
+    private static final String WATER = "7732185";
+    private static final String ETHANOL = "64175";
+    private static final String ASPIRIN = "50782";
+    private static final String COFFEIN = "58082";
+    private static final String FORMALDEHYDE = "50000";
+    private static final String DEXAMETHASONE = "50022";
+    private static final String ARSENIC = "7440382";
+    private static final String ASBESTOS = "1332214";
+    private static final String MAX = "9999999995"; // theoretical
 
     /**
      * Sets up routine & valid codes.
@@ -41,18 +42,9 @@ public class CASNumberCheckDigitTest extends AbstractCheckDigitTest {
     protected void setUp() {
         routine = CASNumberCheckDigit.getInstance();
         valid = new String[] {MIN, WATER, ETHANOL, ASPIRIN, COFFEIN, FORMALDEHYDE, DEXAMETHASONE, ARSENIC, ASBESTOS, MAX};
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    protected String removeCheckDigit(final String code) {
-        String cde = (String) CASNumberCheckDigit.REGEX_VALIDATOR.validate(code);
-        if (cde == null || cde.length() <= checkDigitLth) {
-            return null;
-        }
-        return cde.substring(0, cde.length() - checkDigitLth);
+        invalid = new String[] { "10005", // wrong check
+                "7732-18-5", // format chars
+                " 9999999995", "9999999995 ", " 9999999995 ", };
     }
 
 }

--- a/src/test/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigitTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigitTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.BeforeEach;
  */
 public class CASNumberCheckDigitTest extends AbstractCheckDigitTest {
 
-	// valid CAS Number with dashes removed
+    // valid CAS Number with dashes removed
     private static final String MIN = "10004"; // theoretical
     private static final String WATER = "7732185";
     private static final String ETHANOL = "64175";

--- a/src/test/java/org/apache/commons/validator/routines/checkdigit/ECIndexNumberCheckDigitTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/checkdigit/ECIndexNumberCheckDigitTest.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.validator.routines.checkdigit;
+
+import org.junit.jupiter.api.BeforeEach;
+
+/**
+ * EC Index Number Check Digit Tests.
+ */
+public class ECIndexNumberCheckDigitTest extends AbstractCheckDigitTest {
+
+    private static final String MIN = "000000018"; // theoretical
+    private static final String HYDROGEN = "001001009"; // the first entry
+    private static final String LITHIUM = "003001004";
+    private static final String HCL = "01700201X"; // Hydrochloric acid, Salzsäure
+    private static final String ARSENIC = "03300100X";
+    private static final String KRESOXIM = "607310000"; // kresoxim-methyl
+    private static final String ASBESTOS = "650013006";
+    private static final String MAX = "999999995"; // theoretical
+
+    /**
+     * Sets up routine & valid codes.
+     */
+    @BeforeEach
+    protected void setUp() {
+        routine = ECIndexNumberCheckDigit.getInstance();
+        valid = new String[] {MIN, HYDROGEN, LITHIUM, HCL, ARSENIC, KRESOXIM, ASBESTOS, MAX};
+    }
+
+}

--- a/src/test/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigitTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigitTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.BeforeEach;
  */
 public class ECNumberCheckDigitTest extends AbstractCheckDigitTest {
 
-	// valid EC Number with dashes removed
+    // valid EC Number with dashes removed
     private static final String MIN = "2000002"; // theoretical minimum
     private static final String FORMALDEHYDE = "2000018";
     private static final String DEXAMETHASONE = "2000039";

--- a/src/test/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigitTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigitTest.java
@@ -23,12 +23,13 @@ import org.junit.jupiter.api.BeforeEach;
  */
 public class ECNumberCheckDigitTest extends AbstractCheckDigitTest {
 
-    private static final String MIN = "000-001-6"; // theoretical
-    private static final String FORMALDEHYDE = "200-001-8"; // this is the first entry in EINECS
-    private static final String DEXAMETHASONE = "200-003-9";
-    private static final String ARSENIC = "231-148-6";
-    private static final String ASBESTOS = "603-721-4";
-    private static final String MAX = "999-999-2"; // theoretical
+	// valid EC Number with dashes removed
+    private static final String MIN = "2000002"; // theoretical minimum
+    private static final String FORMALDEHYDE = "2000018";
+    private static final String DEXAMETHASONE = "2000039";
+    private static final String ARSENIC = "2311486";
+    private static final String ASBESTOS = "6037214";
+    private static final String MAX = "9999992"; // theoretical
 
     /**
      * Sets up routine & valid codes.
@@ -37,18 +38,9 @@ public class ECNumberCheckDigitTest extends AbstractCheckDigitTest {
     protected void setUp() {
         routine = ECNumberCheckDigit.getInstance();
         valid = new String[] {MIN, FORMALDEHYDE, DEXAMETHASONE, ARSENIC, ASBESTOS, MAX};
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    protected String removeCheckDigit(final String code) {
-        String cde = (String) ECNumberCheckDigit.REGEX_VALIDATOR.validate(code);
-        if (cde == null || cde.length() <= checkDigitLth) {
-            return null;
-        }
-        return cde.substring(0, cde.length() - checkDigitLth);
+        invalid = new String[] { "0000014", // wrong check
+                "200-001-8", // format chars
+                " 9999992", "9999992 ", " 9999992 ", };
     }
 
 }


### PR DESCRIPTION
routines in package `org.apache.commons.validator.routines.checkdigit`
<b>do not validate</b> the input for length or syntax.

So I change CASNumberCheckDigit and ECNumberCheckDigit.

And provide CASNumberValidator and ECNumberValidator which validates the syntax.

I also add a Validator for ECIndexNumber, a unique nine-digit identifier that is assigned to hazardous chemical substances. 

regards