### PR TITLE
Fix grammar issues in the JavaDoc comments

### DIFF
--- a/src/main/java/org/apache/commons/validator/EmailValidator.java
+++ b/src/main/java/org/apache/commons/validator/EmailValidator.java
@@ -188,7 +188,7 @@ public class EmailValidator {
     /**
      * Returns true if the user component of an email address is valid.
      * @param user being validated
-     * @return true if the user name is valid.
+     * @return true if the username is valid.
      */
     protected boolean isValidUser(final String user) {
         return USER_PATTERN.matcher(user).matches();

--- a/src/main/java/org/apache/commons/validator/Field.java
+++ b/src/main/java/org/apache/commons/validator/Field.java
@@ -609,7 +609,7 @@ public class Field implements Cloneable, Serializable {
 
     /**
      * If there is a value specified for the indexedProperty field then
-     * {@code true} will be returned.  Otherwise it will be
+     * {@code true} will be returned.  Otherwise, it will be
      * {@code false}.
      * @return Whether the Field is indexed.
      */
@@ -715,7 +715,7 @@ public class Field implements Cloneable, Serializable {
      * @param results
      * @param actions
      * @param pos
-     * @return true if all of the dependent validations passed.
+     * @return true if all dependent validations passed.
      * @throws ValidatorException If there's an error running a validator
      */
     private boolean runDependentValidators(

--- a/src/main/java/org/apache/commons/validator/GenericTypeValidator.java
+++ b/src/main/java/org/apache/commons/validator/GenericTypeValidator.java
@@ -312,7 +312,7 @@ public class GenericTypeValidator implements Serializable {
     }
 
     /**
-     * Checks if the value can safely be converted to a int primitive.
+     * Checks if the value can safely be converted to an int primitive.
      *
      * @param value The value validation is being performed on.
      * @return the converted Integer value.

--- a/src/main/java/org/apache/commons/validator/GenericValidator.java
+++ b/src/main/java/org/apache/commons/validator/GenericValidator.java
@@ -47,7 +47,7 @@ public class GenericValidator implements Serializable {
     /**
      * Calculate an adjustment amount for line endings.
      *
-     * See Bug 37962 for the rational behind this.
+     * See Bug 37962 for the rationale behind this.
      *
      * @param value The value validation is being performed on.
      * @param lineEndLength The length to use for line endings.
@@ -239,7 +239,7 @@ public class GenericValidator implements Serializable {
     }
 
     /**
-     * <p>Checks if the value can safely be converted to a int primitive.</p>
+     * <p>Checks if the value can safely be converted to an int primitive.</p>
      *
      * @param value The value validation is being performed on.
      * @return true if the value can be converted to an Integer.

--- a/src/main/java/org/apache/commons/validator/UrlValidator.java
+++ b/src/main/java/org/apache/commons/validator/UrlValidator.java
@@ -138,7 +138,7 @@ public class UrlValidator implements Serializable {
     private static final int PARSE_URL_FRAGMENT = 9;
 
     /**
-     * Protocol (ie. http:, ftp:,https:).
+     * Protocol (i.e. http:, ftp:,https:).
      */
     private static final Pattern SCHEME_PATTERN = Pattern.compile("^\\p{Alpha}[\\p{Alnum}\\+\\-\\.]*");
 
@@ -346,7 +346,7 @@ public class UrlValidator implements Serializable {
             final String topLevel = domainSegment[segmentCount - 1];
 
 
-            // First letter of top level must be a alpha
+            // First letter of top level must be an alpha
             // Make sure there's a host name preceding the authority.
             if (topLevel.length() < TOP_LEVEL_MIN_LEN || topLevel.length() > TOP_LEVEL_MAX_LEN || !ALPHA_PATTERN.matcher(topLevel.substring(0, 1)).matches()
                     || segmentCount < 2) {
@@ -409,7 +409,7 @@ public class UrlValidator implements Serializable {
     }
 
     /**
-     * Returns true if the query is null or it's a properly formatted query string.
+     * Returns true if the query is null, or it's a properly formatted query string.
      * @param query Query value to validate.
      * @return true if query is valid.
      */
@@ -422,8 +422,8 @@ public class UrlValidator implements Serializable {
     }
 
     /**
-     * Validate scheme. If schemes[] was initialized to a non null,
-     * then only those scheme's are allowed.  Note this is slightly different
+     * Validate scheme. If schemes[] was initialized to a non-null,
+     * then only those schemes are allowed.  Note this is slightly different
      * than for the constructor.
      * @param scheme The scheme to validate.  A {@code null} value is considered
      * invalid.

--- a/src/main/java/org/apache/commons/validator/ValidatorAction.java
+++ b/src/main/java/org/apache/commons/validator/ValidatorAction.java
@@ -77,7 +77,7 @@ public class ValidatorAction implements Serializable {
 
     /**
      * <p>
-     * The method signature of the validation method. This should be a comma delimited list of the full class names of each parameter in the correct order that
+     * The method signature of the validation method. This should be a comma-delimited list of the full class names of each parameter in the correct order that
      * the method takes.
      * </p>
      * <p>
@@ -668,7 +668,7 @@ public class ValidatorAction implements Serializable {
      * {@code setJavascript} will result in an {@code IllegalStateException} being thrown.
      * </p>
      * <p>
-     * If <strong>neither</strong> setJsFunction or setJavascript is set then validator will attempt to load the default JavaScript definition.
+     * If <strong>neither</strong> setJsFunction nor setJavascript is set then validator will attempt to load the default JavaScript definition.
      * </p>
      *
      * <pre>

--- a/src/main/java/org/apache/commons/validator/ValidatorResources.java
+++ b/src/main/java/org/apache/commons/validator/ValidatorResources.java
@@ -130,8 +130,7 @@ public class ValidatorResources implements Serializable {
      *
      * @param in InputStream to a validation.xml configuration file.  It's the client's
      * responsibility to close this stream.
-     * @throws SAXException if the validation XML files are not valid or well
-     * formed.
+     * @throws SAXException if the validation XML files are not valid or well-formed.
      * @throws IOException if an I/O error occurs processing the XML files
      * @since 1.1
      */
@@ -145,8 +144,7 @@ public class ValidatorResources implements Serializable {
      * @param streams An array of InputStreams to several validation.xml
      * configuration files that will be read in order and merged into this object.
      * It's the client's responsibility to close these streams.
-     * @throws SAXException if the validation XML files are not valid or well
-     * formed.
+     * @throws SAXException if the validation XML files are not valid or well-formed.
      * @throws IOException if an I/O error occurs processing the XML files
      * @since 1.1
      */
@@ -169,8 +167,7 @@ public class ValidatorResources implements Serializable {
      * Create a ValidatorResources object from an uri
      *
      * @param uri The location of a validation.xml configuration file.
-     * @throws SAXException if the validation XML files are not valid or well
-     * formed.
+     * @throws SAXException if the validation XML files are not valid or well-formed.
      * @throws IOException if an I/O error occurs processing the XML files
      * @since 1.2
      */
@@ -183,8 +180,7 @@ public class ValidatorResources implements Serializable {
      *
      * @param uris An array of uris to several validation.xml
      * configuration files that will be read in order and merged into this object.
-     * @throws SAXException if the validation XML files are not valid or well
-     * formed.
+     * @throws SAXException if the validation XML files are not valid or well-formed.
      * @throws IOException if an I/O error occurs processing the XML files
      * @since 1.2
      */
@@ -205,8 +201,7 @@ public class ValidatorResources implements Serializable {
      *
      * @param url The URL for the validation.xml
      * configuration file that will be read into this object.
-     * @throws SAXException if the validation XML file are not valid or well
-     * formed.
+     * @throws SAXException if the validation XML file are not valid or well-formed.
      * @throws IOException if an I/O error occurs processing the XML files
      * @since 1.3.1
      */
@@ -220,8 +215,7 @@ public class ValidatorResources implements Serializable {
      *
      * @param urls An array of URL to several validation.xml
      * configuration files that will be read in order and merged into this object.
-     * @throws SAXException if the validation XML files are not valid or well
-     * formed.
+     * @throws SAXException if the validation XML files are not valid or well-formed.
      * @throws IOException if an I/O error occurs processing the XML files
      * @since 1.3.1
      */
@@ -335,7 +329,7 @@ public class ValidatorResources implements Serializable {
     }
 
     /**
-     * Builds a key to store the {@code FormSet} under based on it's
+     * Builds a key to store the {@code FormSet} under based on its
      * language, country, and variant values.
      * @param fs The Form Set.
      * @return generated key for a formset.
@@ -543,7 +537,7 @@ public class ValidatorResources implements Serializable {
     }
 
     /**
-     * Gets a {@code ValidatorAction} based on it's name.
+     * Gets a {@code ValidatorAction} based on its name.
      * @param key The validator action key.
      * @return The validator action.
      */
@@ -590,7 +584,7 @@ public class ValidatorResources implements Serializable {
     }
 
     /**
-     * Process the {@code ValidatorResources} object. Currently sets the
+     * Process the {@code ValidatorResources} object. Currently, sets the
      * {@code FastHashMap} s to the 'fast' mode and call the processes
      * all other resources. <strong>Note </strong>: The framework calls this
      * automatically when ValidatorResources is created from an XML file. If you

--- a/src/main/java/org/apache/commons/validator/ValidatorResults.java
+++ b/src/main/java/org/apache/commons/validator/ValidatorResults.java
@@ -45,7 +45,7 @@ public class ValidatorResults implements Serializable {
     }
 
     /**
-     * Add a the result of a validator action.
+     * Add the result of a validator action.
      *
      * @param field The field validated.
      * @param validatorName The name of the validator.
@@ -56,7 +56,7 @@ public class ValidatorResults implements Serializable {
     }
 
     /**
-     * Add a the result of a validator action.
+     * Add the result of a validator action.
      *
      * @param field The field validated.
      * @param validatorName The name of the validator.

--- a/src/main/java/org/apache/commons/validator/package-info.java
+++ b/src/main/java/org/apache/commons/validator/package-info.java
@@ -39,7 +39,7 @@
  * <p>In order to use the Validator, the following basic steps are required:</p>
  * <ul>
  * <li>Create a new instance of the
- * {@code org.apache.commons.validator.Validator} class.  Currently
+ * {@code org.apache.commons.validator.Validator} class. Currently,
  * Validator instances may be safely reused if the current ValidatorResources
  * are the same, as long as
  * you have completed any previous validation, and you do not try to utilize
@@ -68,7 +68,7 @@
  * using the Apache Commons BeanUtils
  * (https://commons.apache.org/beanutils/) package.
  * Error messages and the arguments for error messages can be
- * associated with a fields validation.
+ * associated with a field's validation.
  * </p>
  * <a id="doc.Resources"></a>
  * <h2>Resources</h2>

--- a/src/main/java/org/apache/commons/validator/routines/AbstractCalendarValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/AbstractCalendarValidator.java
@@ -103,7 +103,7 @@ public abstract class AbstractCalendarValidator extends AbstractFormatValidator 
 
     /**
      * <p>Compares a calendar value to another, indicating whether it is
-     *    equal, less then or more than at a specified level.</p>
+     *    equal, less than or more than at a specified level.</p>
      *
      * @param value The Calendar value.
      * @param compare The {@link Calendar} to check the value against.
@@ -159,7 +159,7 @@ public abstract class AbstractCalendarValidator extends AbstractFormatValidator 
 
     /**
      * <p>Compares a calendar's quarter value to another, indicating whether it is
-     *    equal, less then or more than the specified quarter.</p>
+     *    equal, less than or more than the specified quarter.</p>
      *
      * @param value The Calendar value.
      * @param compare The {@link Calendar} to check the value against.
@@ -175,7 +175,7 @@ public abstract class AbstractCalendarValidator extends AbstractFormatValidator 
 
     /**
      * <p>Compares a calendar time value to another, indicating whether it is
-     *    equal, less then or more than at a specified level.</p>
+     *    equal, less than or more than at a specified level.</p>
      *
      * @param value The Calendar value.
      * @param compare The {@link Calendar} to check the value against.
@@ -241,7 +241,7 @@ public abstract class AbstractCalendarValidator extends AbstractFormatValidator 
      * @param value The value validation is being performed on.
      * @param locale The locale to use for the Format.
      * @param timeZone The Time Zone used to format the date,
-     *  system default if null (unless value is a {@link Calendar}.
+     *  system default if null unless value is a {@link Calendar}.
      * @return The value formatted as a {@link String}.
      */
     public String format(final Object value, final Locale locale, final TimeZone timeZone) {
@@ -270,7 +270,7 @@ public abstract class AbstractCalendarValidator extends AbstractFormatValidator 
      * @param pattern The pattern used to format the value.
      * @param locale The locale to use for the Format.
      * @param timeZone The Time Zone used to format the date,
-     *  system default if null (unless value is a {@link Calendar}.
+     *  system default if null unless value is a {@link Calendar}.
      * @return The value formatted as a {@link String}.
      */
     public String format(final Object value, final String pattern, final Locale locale, final TimeZone timeZone) {
@@ -290,7 +290,7 @@ public abstract class AbstractCalendarValidator extends AbstractFormatValidator 
      * @param value The value validation is being performed on.
      * @param pattern The pattern used to format the value.
      * @param timeZone The Time Zone used to format the date,
-     *  system default if null (unless value is a {@link Calendar}.
+     *  system default if null unless value is a {@link Calendar}.
      * @return The value formatted as a {@link String}.
      */
     public String format(final Object value, final String pattern, final TimeZone timeZone) {
@@ -303,7 +303,7 @@ public abstract class AbstractCalendarValidator extends AbstractFormatValidator 
      *
      * @param value The value validation is being performed on.
      * @param timeZone The Time Zone used to format the date,
-     *  system default if null (unless value is a {@link Calendar}.
+     *  system default if null unless value is a {@link Calendar}.
      * @return The value formatted as a {@link String}.
      */
     public String format(final Object value, final TimeZone timeZone) {

--- a/src/main/java/org/apache/commons/validator/routines/CalendarValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/CalendarValidator.java
@@ -35,7 +35,7 @@ import java.util.TimeZone;
  *       <li>using a specified pattern with a specified {@link Locale}</li>
  *    </ul>
  *
- * <p>For each of the above mechanisms, conversion method (i.e the
+ * <p>For each of the above mechanisms, conversion method (i.e. the
  *    {@code validate} methods) implementations are provided which
  *    either use the default {@code TimeZone} or allow the
  *    {@code TimeZone} to be specified.</p>
@@ -50,7 +50,7 @@ import java.util.TimeZone;
  *
  * <p>Alternatively the CalendarValidator's {@code adjustToTimeZone()} method
  *    can be used to adjust the {@code TimeZone} of the {@link Calendar}
- *    object afterwards.</p>
+ *    object afterward.</p>
  *
  * <p>Once a value has been successfully converted the following
  *    methods can be used to perform various date comparison checks:</p>

--- a/src/main/java/org/apache/commons/validator/routines/CodeValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/CodeValidator.java
@@ -59,7 +59,7 @@ import org.apache.commons.validator.routines.checkdigit.CheckDigit;
  *    </ul>
  * <p>
  * Codes often include <em>format</em> characters - such as hyphens - to make them
- * more easily human readable. These can be removed prior to length and check digit
+ * more easily human-readable. These can be removed prior to length and check digit
  * validation by  specifying them as a <em>non-capturing</em> group in the regular
  * expression (i.e. use the {@code (?:   )} notation).
  * <br>

--- a/src/main/java/org/apache/commons/validator/routines/CreditCardValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/CreditCardValidator.java
@@ -474,7 +474,7 @@ public class CreditCardValidator implements Serializable {
 
     /**
      * Tests whether the given flag is on.  If the flag is not a power of 2
-     * (ie. 3) this tests whether the combination of flags is on.
+     * (i.e. 3) this tests whether the combination of flags is on.
      *
      * @param options The options specified.
      * @param flag Flag value to check.

--- a/src/main/java/org/apache/commons/validator/routines/CurrencyValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/CurrencyValidator.java
@@ -35,7 +35,7 @@ import java.text.Format;
  *
  *    <p>{@code ... = new IntegerValidator(false, IntegerValidator.CURRENCY_FORMAT);}</p>
  *
- * <p>Pick the appropriate validator, depending on the type (e.g Float, Double, Integer, Long etc)
+ * <p>Pick the appropriate validator, depending on the type (e.g. Float, Double, Integer, Long etc)
  *    you want the currency converted to. One thing to note - only the CurrencyValidator
  *    implements <em>lenient</em> behavior regarding the currency symbol.</p>
  *

--- a/src/main/java/org/apache/commons/validator/routines/DateValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/DateValidator.java
@@ -36,7 +36,7 @@ import java.util.TimeZone;
  *       <li>using a specified pattern with a specified {@link Locale}</li>
  *    </ul>
  *
- * <p>For each of the above mechanisms, conversion method (i.e the
+ * <p>For each of the above mechanisms, conversion method (i.e. the
  *    {@code validate} methods) implementations are provided which
  *    either use the default {@code TimeZone} or allow the
  *    {@code TimeZone} to be specified.</p>

--- a/src/main/java/org/apache/commons/validator/routines/DomainValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/DomainValidator.java
@@ -2288,7 +2288,7 @@ public class DomainValidator implements Serializable {
      * widely used "local" domains (localhost or localdomain). Leading dots are
      * ignored if present. The search is case-insensitive.
      * @param lTld the parameter to check for local TLD status, not null
-     * @return true if the parameter is an local TLD
+     * @return true if the parameter is a local TLD
      */
     public boolean isValidLocalTld(final String lTld) {
         final String key = chompLeadingDot(unicodeToASCII(lTld).toLowerCase(Locale.ENGLISH));

--- a/src/main/java/org/apache/commons/validator/routines/EmailValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/EmailValidator.java
@@ -216,7 +216,7 @@ public class EmailValidator implements Serializable {
      * Returns true if the user component of an email address is valid.
      *
      * @param user being validated
-     * @return true if the user name is valid.
+     * @return true if the username is valid.
      */
     protected boolean isValidUser(final String user) {
 

--- a/src/main/java/org/apache/commons/validator/routines/IBANValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/IBANValidator.java
@@ -237,14 +237,14 @@ public class IBANValidator {
     /*
      * Wikipedia [1] says that only uppercase is allowed.
      * The SWIFT PDF file [2] implies that lower case is allowed.
-     * However there are no examples using lower-case.
+     * However, there are no examples using lower-case.
      * Unfortunately the relevant ISO documents (ISO 13616-1) are not available for free.
      * The IBANCheckDigit code treats upper and lower case the same,
      * so any case validation has to be done in this class.
      *
      * Note: the European Payments council has a document [3] which includes a description
      * of the IBAN. Section 5 clearly states that only upper case is allowed.
-     * Also the maximum length is 34 characters (including the country code),
+     * Also, the maximum length is 34 characters (including the country code),
      * and the length is fixed for each country.
      *
      * It looks like lower-case is permitted in BBANs, but they must be converted to

--- a/src/main/java/org/apache/commons/validator/routines/ISBNValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/ISBNValidator.java
@@ -28,7 +28,7 @@ import org.apache.commons.validator.routines.checkdigit.ISBN10CheckDigit;
  * <p>
  * This validator validates the code is either a valid ISBN-10
  * (using a {@link CodeValidator} with the {@link ISBN10CheckDigit})
- * or a valid ISBN-13 code (using a {@link CodeValidator} with the
+ * or a valid ISBN-13 code (using a {@link CodeValidator} with
  * the {@link EAN13CheckDigit} routine).
  * <p>
  * The {@code validate()} methods return the ISBN code with formatting
@@ -61,7 +61,7 @@ import org.apache.commons.validator.routines.checkdigit.ISBN10CheckDigit;
  *     <li>979-10, 979-11, 979-12 are assigned to the ISBN agency</li>
  * </ul>
  * All other 979 prefixed EAN-13 numbers have not yet been assigned to an agency. The
- * validator validates all 13 digit codes with 978 or 979 prefixes.
+ * validator validates all 13-digit codes with 978 or 979 prefixes.
  *
  * @since 1.4
  */

--- a/src/main/java/org/apache/commons/validator/routines/ISINValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/ISINValidator.java
@@ -32,7 +32,7 @@ import org.apache.commons.validator.routines.checkdigit.ISINCheckDigit;
  * <p>
  * ISINs consist of two alphabetic characters,
  * which are the ISO 3166-1 alpha-2 code for the issuing country,
- * nine alpha-numeric characters (the National Securities Identifying Number, or NSIN, which identifies the security),
+ * nine alphanumeric characters (the National Securities Identifying Number, or NSIN, which identifies the security),
  * and one numerical check digit.
  * They are 12 characters in length.
  * </p>

--- a/src/main/java/org/apache/commons/validator/routines/PercentValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/PercentValidator.java
@@ -36,10 +36,10 @@ import java.text.Format;
  *
  *    <p>{@code ... = new FloatValidator(false, FloatValidator.PERCENT_FORMAT);}</p>
  *
- * <p>Pick the appropriate validator, depending on the type (i.e Float, Double or BigDecimal)
+ * <p>Pick the appropriate validator, depending on the type (i.e. Float, Double or BigDecimal)
  *    you want the percent converted to. Please note, it makes no sense to use
  *    one of the validators that doesn't handle fractions (i.e. byte, short, integer, long
- *    and BigInteger) since percentages are converted to fractions (i.e {@code 50%} is
+ *    and BigInteger) since percentages are converted to fractions (i.e. {@code 50%} is
  *    converted to {@code 0.5}).</p>
  *
  * @since 1.3.0

--- a/src/main/java/org/apache/commons/validator/routines/RegexValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/RegexValidator.java
@@ -24,7 +24,7 @@ import java.util.regex.Pattern;
 /**
  * <strong>Regular Expression</strong> validation (using the JRE's regular expression support).
  * <p>
- * Constructs the validator either for a single regular expression or a set (array) of regular expressions. By default validation is <em>case sensitive</em> but
+ * Constructs the validator either for a single regular expression or a set (array) of regular expressions. By default, validation is <em>case sensitive</em> but
  * constructors are provided to allow <em>case in-sensitive</em> validation. For example to create a validator which does <em>case in-sensitive</em> validation
  * for a set of regular expressions:
  * </p>

--- a/src/main/java/org/apache/commons/validator/routines/TimeValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/TimeValidator.java
@@ -35,7 +35,7 @@ import java.util.TimeZone;
  *       <li>using a specified pattern with a specified {@link Locale}</li>
  *    </ul>
  *
- * <p>For each of the above mechanisms, conversion method (i.e the
+ * <p>For each of the above mechanisms, conversion method (i.e. the
  *    {@code validate} methods) implementations are provided which
  *    either use the default {@code TimeZone} or allow the
  *    {@code TimeZone} to be specified.</p>

--- a/src/main/java/org/apache/commons/validator/routines/UrlValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/UrlValidator.java
@@ -325,7 +325,7 @@ public class UrlValidator implements Serializable {
 
     /**
      * Tests whether the given flag is off.  If the flag is not a power of 2
-     * (ie. 3) this tests whether the combination of flags is off.
+     * (i.e. 3) this tests whether the combination of flags is off.
      *
      * @param flag Flag value to check.
      * @return whether the specified flag value is off.
@@ -336,7 +336,7 @@ public class UrlValidator implements Serializable {
 
     /**
      * Tests whether the given flag is on.  If the flag is not a power of 2
-     * (ie. 3) this tests whether the combination of flags is on.
+     * (i.e. 3) this tests whether the combination of flags is on.
      *
      * @param flag Flag value to check.
      * @return whether the specified flag value is on.
@@ -388,7 +388,7 @@ public class UrlValidator implements Serializable {
      * Returns true if the authority is properly formatted.  An authority is the combination
      * of hostname and port.  A {@code null} authority value is considered invalid.
      * Note: this implementation validates the domain unless a RegexValidator was provided.
-     * If a RegexValidator was supplied and it matches, then the authority is regarded
+     * If a RegexValidator was supplied, and it matches, then the authority is regarded
      * as valid with no further checks, otherwise the method checks against the
      * AUTHORITY_PATTERN and the DomainValidator (ALLOW_LOCAL_URLS)
      * @param authority Authority value to validate, allows IDN
@@ -495,7 +495,7 @@ public class UrlValidator implements Serializable {
     }
 
     /**
-     * Returns true if the query is null or it's a properly formatted query string.
+     * Returns true if the query is null, or it's a properly formatted query string.
      * @param query Query value to validate.
      * @return true if query is valid.
      */
@@ -507,9 +507,9 @@ public class UrlValidator implements Serializable {
     }
 
     /**
-     * Validate scheme. If schemes[] was initialized to a non null,
+     * Validate scheme. If schemes[] was initialized to a non-null,
      * then only those schemes are allowed.
-     * Otherwise the default schemes are "http", "https", "ftp".
+     * Otherwise, the default schemes are "http", "https", "ftp".
      * Matching is case-blind.
      * @param scheme The scheme to validate.  A {@code null} value is considered
      * invalid.

--- a/src/main/java/org/apache/commons/validator/routines/package-info.java
+++ b/src/main/java/org/apache/commons/validator/routines/package-info.java
@@ -420,8 +420,8 @@
  * of the matched <em>groups</em> or {@code null} if invalid.</li>
  * </ul>
  * </li>
- * <li><strong>Case Sensitivity</strong> - matching can be done in either a <i>case
- * sensitive</i> or <em>case in-sensitive</em> way.</li>
+ * <li><strong>Case Sensitivity</strong> - matching can be done in either a
+ * <i>case-sensitive</i> or <em>case in-sensitive</em> way.</li>
  * <li><strong>Multiple Expressions</strong> - instances of the
  * <a href="RegexValidator.html">RegexValidator</a>
  * can be created to either match against a single regular expression

--- a/src/main/java/org/apache/commons/validator/util/Flags.java
+++ b/src/main/java/org/apache/commons/validator/util/Flags.java
@@ -122,7 +122,7 @@ public class Flags implements Serializable, Cloneable {
 
     /**
      * Tests whether the given flag is off.  If the flag is not a power of 2
-     * (ie. 3) this tests whether the combination of flags is off.
+     * (i.e. 3) this tests whether the combination of flags is off.
      *
      * @param flag Flag value to check.
      * @return whether the specified flag value is off.
@@ -133,7 +133,7 @@ public class Flags implements Serializable, Cloneable {
 
     /**
      * Tests whether the given flag is on.  If the flag is not a power of 2
-     * (ie. 3) this tests whether the combination of flags is on.
+     * (i.e. 3) this tests whether the combination of flags is on.
      *
      * @param flag Flag value to check.
      * @return whether the specified flag value is on.
@@ -159,7 +159,7 @@ public class Flags implements Serializable, Cloneable {
     }
 
     /**
-     * Turns off the given flag.  If the flag is not a power of 2 (ie. 3) this
+     * Turns off the given flag.  If the flag is not a power of 2 (i.e. 3) this
      * turns off multiple flags.
      *
      * @param flag Flag value to turn off.
@@ -176,7 +176,7 @@ public class Flags implements Serializable, Cloneable {
     }
 
     /**
-     * Turns on the given flag.  If the flag is not a power of 2 (ie. 3) this
+     * Turns on the given flag.  If the flag is not a power of 2 (i.e. 3) this
      * turns on multiple flags.
      *
      * @param flag Flag value to turn on.

--- a/src/main/java/org/apache/commons/validator/util/ValidatorUtils.java
+++ b/src/main/java/org/apache/commons/validator/util/ValidatorUtils.java
@@ -44,7 +44,7 @@ public class ValidatorUtils {
     /**
      * Makes a deep copy of a {@code FastHashMap} if the values
      * are {@code Msg}, {@code Arg},
-     * or {@code Var}.  Otherwise it is a shallow copy.
+     * or {@code Var}. Otherwise, it is a shallow copy.
      *
      * @param fastHashMap {@code FastHashMap} to copy.
      * @return FastHashMap A copy of the {@code FastHashMap} that was


### PR DESCRIPTION
- Comparison requires 'than', not 'then'.
- Use 'a' instead of 'an' or vice versa.
- The abbreviations 'i.e.' and 'e.g.' requires two periods.
- Some words are spelled with hyphen
- Some words spelled as one word instead of two
- Repeated words (e.g. 'the the')
- Missing comma
- Plural instead of possessive
- Possessive instead of "it's" (short for "it is")