### PR TITLE
Switch to use commons-digester3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -169,20 +169,9 @@
       <version>1.10.1</version>
     </dependency>
     <dependency>
-      <groupId>commons-digester</groupId>
-      <artifactId>commons-digester</artifactId>
-      <version>2.1</version>
-      <!-- exclude older version and use declared-only -->
-      <exclusions>
-        <exclusion>
-          <groupId>commons-beanutils</groupId>
-          <artifactId>commons-beanutils</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>commons-logging</groupId>
-          <artifactId>commons-logging</artifactId>
-        </exclusion>
-      </exclusions>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-digester3</artifactId>
+      <version>3.2</version>
     </dependency>
     <dependency>
       <groupId>commons-logging</groupId>

--- a/src/main/java/org/apache/commons/validator/FormSetFactory.java
+++ b/src/main/java/org/apache/commons/validator/FormSetFactory.java
@@ -16,7 +16,7 @@
  */
 package org.apache.commons.validator;
 
-import org.apache.commons.digester.AbstractObjectCreationFactory;
+import org.apache.commons.digester3.AbstractObjectCreationFactory;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.xml.sax.Attributes;
@@ -26,7 +26,7 @@ import org.xml.sax.Attributes;
  *
  * @since 1.2
  */
-public class FormSetFactory extends AbstractObjectCreationFactory {
+public class FormSetFactory extends AbstractObjectCreationFactory<FormSet> {
 
     /** Logging */
     private transient Log log = LogFactory.getLog(FormSetFactory.class);
@@ -89,9 +89,9 @@ public class FormSetFactory extends AbstractObjectCreationFactory {
      * @throws Exception If an error occurs creating the FormSet.
      */
     @Override
-    public Object createObject(final Attributes attributes) throws Exception {
+    public FormSet createObject(final Attributes attributes) throws Exception {
 
-        final ValidatorResources resources = (ValidatorResources) digester.peek(0);
+        final ValidatorResources resources = (ValidatorResources) getDigester().peek(0);
 
         final String language = attributes.getValue("language");
         final String country = attributes.getValue("country");

--- a/src/main/java/org/apache/commons/validator/ValidatorResources.java
+++ b/src/main/java/org/apache/commons/validator/ValidatorResources.java
@@ -25,9 +25,10 @@ import java.util.Locale;
 import java.util.Map;
 
 import org.apache.commons.collections.FastHashMap; // DEPRECATED
-import org.apache.commons.digester.Digester;
-import org.apache.commons.digester.Rule;
-import org.apache.commons.digester.xmlrules.DigesterLoader;
+import org.apache.commons.digester3.Digester;
+import org.apache.commons.digester3.Rule;
+import org.apache.commons.digester3.binder.DigesterLoader;
+import org.apache.commons.digester3.xmlrules.FromXmlRulesModule;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 import org.xml.sax.Attributes;
@@ -557,15 +558,23 @@ public class ValidatorResources implements Serializable {
      *  Initialize the digester.
      */
     private Digester initDigester() {
-        URL rulesUrl = this.getClass().getResource(VALIDATOR_RULES);
-        if (rulesUrl == null) {
-            // Fix for Issue# VALIDATOR-195
-            rulesUrl = ValidatorResources.class.getResource(VALIDATOR_RULES);
-        }
-        if (getLog().isDebugEnabled()) {
-            getLog().debug("Loading rules from '" + rulesUrl + "'");
-        }
-        final Digester digester = DigesterLoader.createDigester(rulesUrl);
+        // Create a digester loader using FromXmlRulesModule
+        DigesterLoader loader = DigesterLoader.newLoader(new FromXmlRulesModule() {
+            @Override
+            protected void loadRules() {
+              URL rulesUrl = this.getClass().getResource(VALIDATOR_RULES);
+              if (rulesUrl == null) {
+                // Fix for Issue# VALIDATOR-195
+                rulesUrl = ValidatorResources.class.getResource(VALIDATOR_RULES);
+              }
+              if (getLog().isDebugEnabled()) {
+                getLog().debug("Loading rules from '" + rulesUrl + "'");
+              }
+              loadXMLRules(rulesUrl);
+            }
+        });
+        Digester digester = loader.newDigester();
+
         digester.setNamespaceAware(true);
         digester.setValidating(true);
         digester.setUseContextClassLoader(true);

--- a/src/main/resources/org/apache/commons/validator/digester-rules.xml
+++ b/src/main/resources/org/apache/commons/validator/digester-rules.xml
@@ -22,8 +22,8 @@
 -->
 
 
-<!DOCTYPE digester-rules PUBLIC "-//Jakarta Apache //DTD digester-rules XML V1.0//EN" 
-    "http://jakarta.apache.org/commons/digester/dtds/digester-rules.dtd">
+<!DOCTYPE digester-rules PUBLIC "-//Apache Commons //DTD digester-rules XML V1.0//EN" 
+    "http://commons.apache.org/digester/dtds/digester-rules-3.0.dtd">
 
 <digester-rules>
 


### PR DESCRIPTION
<!--
  Licensed to the Apache Software Foundation (ASF) under one
  or more contributor license agreements.  See the NOTICE file
  distributed with this work for additional information
  regarding copyright ownership.  The ASF licenses this file
  to you under the Apache License, Version 2.0 (the
  "License"); you may not use this file except in compliance
  with the License.  You may obtain a copy of the License at

    http://www.apache.org/licenses/LICENSE-2.0

  Unless required by applicable law or agreed to in writing,
  software distributed under the License is distributed on an
  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
  KIND, either express or implied.  See the License for the
  specific language governing permissions and limitations
  under the License.
-->

Thanks for your contribution to [Apache Commons](https://commons.apache.org/)! Your help is appreciated!

Before you push a pull request, review this list:

- [/] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [/] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [/] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible but is a best-practice.
- [/] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [/] Each commit in the pull request should have a meaningful subject line and body. Note that commits might be squashed by a maintainer on merge.


Changed the dependency on commons-digester to use commons-digester3 instead.

I understand that this may be blocked for a later major version change similarly to #53 
running `japicmp:cmp` yields the following output:

`
[ERROR] Failed to execute goal com.github.siom79.japicmp:japicmp-maven-plugin:0.23.1:cmp (default-cli) on project commons-validator: There is at least one incompatibility: org.apache.commons.digester.ObjectCreationFactory[org.apache.commons.digester.ObjectCreationFactory]:INTERFACE_REMOVED,org.apache.commons.validator.FormSetFactory:SUPERCLASS_REMOVED,org.apache.commons.validator.FormSetFactory:METHOD_ABSTRACT_ADDED_IN_IMPLEMENTED_INTERFACE -> [Help 1]
`
