### PR TITLE
Reject signed hex group in InetAddressValidator.isValidInet6Address(String)

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/InetAddressValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/InetAddressValidator.java
@@ -201,6 +201,9 @@ public class InetAddressValidator implements Serializable {
                 if (octet.length() > IPV6_MAX_HEX_DIGITS_PER_GROUP) {
                     return false;
                 }
+                if (octet.charAt(0) == '+' || octet.charAt(0) == '-') {
+                    return false; // Integer.parseInt accepts a leading sign, which is not a valid hex group
+                }
                 int octetInt = 0;
                 try {
                     octetInt = Integer.parseInt(octet, BASE_16);

--- a/src/test/java/org/apache/commons/validator/routines/InetAddressValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/InetAddressValidatorTest.java
@@ -159,6 +159,9 @@ class InetAddressValidatorTest {
         assertTrue(validator.isValidInet6Address("1:2:3:4:5::7:8"), "IPV6 1:2:3:4:5::7:8 should be valid");
         assertFalse(validator.isValidInet6Address("1:2:3::4:5::7:8"), "IPV6 1:2:3::4:5::7:8 should be invalid"); // Double "::"
         assertFalse(validator.isValidInet6Address("12345::6:7:8"), "IPV6 12345::6:7:8 should be invalid");
+        assertFalse(validator.isValidInet6Address("1:2:3:4:5:6:7:+8"), "IPV6 1:2:3:4:5:6:7:+8 should be invalid"); // signed hex group
+        assertFalse(validator.isValidInet6Address("fe80::+1"), "IPV6 fe80::+1 should be invalid"); // signed hex group
+        assertFalse(validator.isValidInet6Address("::+f"), "IPV6 ::+f should be invalid"); // signed hex group
         assertTrue(validator.isValidInet6Address("1:2:3:4::7:8"), "IPV6 1:2:3:4::7:8 should be valid");
         assertTrue(validator.isValidInet6Address("1:2:3::7:8"), "IPV6 1:2:3::7:8 should be valid");
         assertTrue(validator.isValidInet6Address("1:2::7:8"), "IPV6 1:2::7:8 should be valid");


### PR DESCRIPTION
isValidInet6Address parses each hex group with Integer.parseInt(octet, 16), which tolerates a leading '+', so addresses like 1:2:3:4:5:6:7:+8, fe80::+1 and ::+f are accepted even though they are not valid IPv6 literals (JDK InetAddress.getByName rejects them); the '-' form is already caught by the existing octetInt < 0 check, so only '+' slips through.