### PR TITLE
reject non-ASCII Unicode digits in check-digit routines

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/CUSIPCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/CUSIPCheckDigit.java
@@ -69,7 +69,7 @@ public final class CUSIPCheckDigit extends ModulusCheckDigit {
         final int charValue = Character.getNumericValue(character);
         // the final character is only allowed to reach 9
         final int charMax = rightPos == 1 ? 9 : 35;  // CHECKSTYLE IGNORE MagicNumber
-        if (charValue < 0 || charValue > charMax) {
+        if (character > 0x7F || charValue < 0 || charValue > charMax) {
             throw new CheckDigitException("Invalid Character[" +
                     leftPos + "," + rightPos + "] = '" + charValue + "' out of range 0 to " + charMax);
         }

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/ISINCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/ISINCheckDigit.java
@@ -75,8 +75,9 @@ public final class ISINCheckDigit extends ModulusCheckDigit {
             }
         }
         for (int i = 0; i < code.length(); i++) {
-            final int charValue = Character.getNumericValue(code.charAt(i));
-            if (charValue < 0 || charValue > MAX_ALPHANUMERIC_VALUE) {
+            final char character = code.charAt(i);
+            final int charValue = Character.getNumericValue(character);
+            if (character > 0x7F || charValue < 0 || charValue > MAX_ALPHANUMERIC_VALUE) {
                 throw new CheckDigitException("Invalid Character[" + (i + 1) + "] = '" + charValue + "'");
             }
             // this converts alphanumerics to two digits

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/ModulusCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/ModulusCheckDigit.java
@@ -179,8 +179,8 @@ public abstract class ModulusCheckDigit extends AbstractCheckDigit implements Se
      * @throws CheckDigitException if character is non-numeric
      */
     protected int toInt(final char character, final int leftPos, final int rightPos) throws CheckDigitException {
-        if (Character.isDigit(character)) {
-            return Character.getNumericValue(character);
+        if (character >= '0' && character <= '9') {
+            return character - '0';
         }
         throw new CheckDigitException("Invalid Character[" + leftPos + "] = '" + character + "'");
     }

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/ModulusTenCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/ModulusTenCheckDigit.java
@@ -207,7 +207,7 @@ public final class ModulusTenCheckDigit extends ModulusCheckDigit {
     @Override
     protected int toInt(final char character, final int leftPos, final int rightPos) throws CheckDigitException {
         final int num = Character.getNumericValue(character);
-        if (num < 0) {
+        if (num < 0 || character > 0x7F) {
             throw new CheckDigitException("Invalid Character[" + leftPos + "] = '" + character + "'");
         }
         return num;

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/SedolCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/SedolCheckDigit.java
@@ -87,7 +87,7 @@ public final class SedolCheckDigit extends ModulusCheckDigit {
         final int charValue = Character.getNumericValue(character);
         // the check digit is only allowed to reach 9
         final int charMax = rightPos == 1 ? 9 : MAX_ALPHANUMERIC_VALUE; // CHECKSTYLE IGNORE MagicNumber
-        if (charValue < 0 || charValue > charMax) {
+        if (character > 0x7F || charValue < 0 || charValue > charMax) {
             throw new CheckDigitException("Invalid Character[" + leftPos + "," + rightPos + "] = '" + charValue + "' out of range 0 to " + charMax);
         }
         return charValue;

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/VerhoeffCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/VerhoeffCheckDigit.java
@@ -102,11 +102,12 @@ public final class VerhoeffCheckDigit extends AbstractCheckDigit implements Seri
         int checksum = 0;
         for (int i = 0; i < code.length(); i++) {
             final int idx = code.length() - (i + 1);
-            final int num = Character.getNumericValue(code.charAt(idx));
-            if (num < 0 || num > 9) { // CHECKSTYLE IGNORE MagicNumber
+            final char character = code.charAt(idx);
+            if (character < '0' || character > '9') { // CHECKSTYLE IGNORE MagicNumber
                 throw new CheckDigitException("Invalid Character[" +
-                        i + "] = '" + (int) code.charAt(idx) + "'");
+                        i + "] = '" + (int) character + "'");
             }
+            final int num = character - '0';
             final int pos = includesCheckDigit ? i : i + 1;
             checksum = D_TABLE[checksum][P_TABLE[pos % 8][num]]; // CHECKSTYLE IGNORE MagicNumber
         }

--- a/src/test/java/org/apache/commons/validator/routines/checkdigit/CheckDigitNonAsciiDigitTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/checkdigit/CheckDigitNonAsciiDigitTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.commons.validator.routines.checkdigit;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests that check digit routines reject non-ASCII Unicode digits that
+ * {@code Character.getNumericValue} / {@code Character.isDigit} otherwise map to 0-9.
+ */
+class CheckDigitNonAsciiDigitTest {
+
+    private static String toFullwidth(final String code) {
+        final StringBuilder sb = new StringBuilder(code.length());
+        for (int i = 0; i < code.length(); i++) {
+            final char c = code.charAt(i);
+            sb.append(c >= '0' && c <= '9' ? (char) ('０' + (c - '0')) : c);
+        }
+        return sb.toString();
+    }
+
+    private static String toArabicIndic(final String code) {
+        final StringBuilder sb = new StringBuilder(code.length());
+        for (int i = 0; i < code.length(); i++) {
+            final char c = code.charAt(i);
+            sb.append(c >= '0' && c <= '9' ? (char) ('٠' + (c - '0')) : c);
+        }
+        return sb.toString();
+    }
+
+    private static void assertRejectsNonAscii(final CheckDigit routine, final String validCode) {
+        assertTrue(routine.isValid(validCode), "ASCII: " + validCode);
+        assertFalse(routine.isValid(toFullwidth(validCode)), "fullwidth: " + validCode);
+        assertFalse(routine.isValid(toArabicIndic(validCode)), "arabic-indic: " + validCode);
+    }
+
+    @Test
+    void testCUSIP() {
+        assertRejectsNonAscii(CUSIPCheckDigit.CUSIP_CHECK_DIGIT, "037833100");
+    }
+
+    @Test
+    void testEAN13() {
+        assertRejectsNonAscii(EAN13CheckDigit.EAN13_CHECK_DIGIT, "9780072129519");
+    }
+
+    @Test
+    void testISIN() {
+        assertRejectsNonAscii(ISINCheckDigit.ISIN_CHECK_DIGIT, "US0378331005");
+    }
+
+    @Test
+    void testISBN10() {
+        assertRejectsNonAscii(ISBN10CheckDigit.ISBN10_CHECK_DIGIT, "1930110995");
+    }
+
+    @Test
+    void testISSN() {
+        assertRejectsNonAscii(ISSNCheckDigit.ISSN_CHECK_DIGIT, "03178471");
+    }
+
+    @Test
+    void testLuhn() {
+        assertRejectsNonAscii(LuhnCheckDigit.LUHN_CHECK_DIGIT, "4417123456789113");
+    }
+
+    @Test
+    void testModulusTenLuhn() {
+        assertRejectsNonAscii(new ModulusTenCheckDigit(new int[] { 1, 2 }, true, true), "4417123456789113");
+    }
+
+    @Test
+    void testSedol() {
+        assertRejectsNonAscii(SedolCheckDigit.SEDOL_CHECK_DIGIT, "0263494");
+    }
+
+    @Test
+    void testVerhoeff() {
+        assertRejectsNonAscii(VerhoeffCheckDigit.VERHOEFF_CHECK_DIGIT, "1428570");
+    }
+}


### PR DESCRIPTION
Character.getNumericValue/isDigit accept fullwidth and Arabic-Indic digits, so Unicode-digit codes pass isValid on EAN-13, Luhn, ISIN, CUSIP, SEDOL and Verhoeff; restrict each conversion site to ASCII.