### PR TITLE
reject NaN and infinity in double and float validators

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/DoubleValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/DoubleValidator.java
@@ -193,10 +193,16 @@ public class DoubleValidator extends AbstractNumberValidator {
      */
     @Override
     protected Object processParsedValue(final Object value, final Format formatter) {
+        final double doubleValue = ((Number) value).doubleValue();
+        // The "Infinity"/"-Infinity" strings throw a ParseException, but the locale infinity
+        // symbol parses through to an infinite value; reject it so the two paths are consistent.
+        if (Double.isInfinite(doubleValue)) {
+            return null;
+        }
         if (value instanceof Double) {
             return value;
         }
-        return Double.valueOf(((Number) value).doubleValue());
+        return Double.valueOf(doubleValue);
 
     }
 

--- a/src/main/java/org/apache/commons/validator/routines/FloatValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/FloatValidator.java
@@ -197,6 +197,11 @@ public class FloatValidator extends AbstractNumberValidator {
 
         final double doubleValue = ((Number) value).doubleValue();
 
+        // The "Infinity"/"-Infinity" strings throw a ParseException, but the locale infinity
+        // symbol parses through to an infinite value; reject it so the two paths are consistent.
+        if (Double.isInfinite(doubleValue)) {
+            return null;
+        }
         if (doubleValue > 0) {
             if (doubleValue < Float.MIN_VALUE || doubleValue > Float.MAX_VALUE) {
                 return null;

--- a/src/test/java/org/apache/commons/validator/routines/DoubleValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/DoubleValidatorTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.text.DecimalFormatSymbols;
 import java.util.Locale;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -165,6 +166,20 @@ class DoubleValidatorTest extends AbstractNumberValidatorTest {
         // Double.NEGATIVE_INFINITY -> "-Infinity": NumberFormat cannot parse "-Infinity"
         assertNull(validator.validate(Double.toString(Double.NEGATIVE_INFINITY)));
         assertFalse(validator.isValid(Double.toString(Double.NEGATIVE_INFINITY)));
+    }
+
+    /**
+     * Test the locale infinity symbol is rejected. Unlike the "Infinity" string, the symbol parses through to an infinite value, so it is rejected to keep both
+     * paths consistent. NaN is unaffected.
+     */
+    @Test
+    void testDoubleValidateInfinitySymbol() {
+        final DoubleValidator validator = DoubleValidator.getInstance();
+        final String infinity = new DecimalFormatSymbols(Locale.US).getInfinity();
+        assertNull(validator.validate(infinity, Locale.US), "validate(infinity symbol)");
+        assertNull(validator.validate("-" + infinity, Locale.US), "validate(-infinity symbol)");
+        assertFalse(validator.isValid(infinity, Locale.US), "isValid(infinity symbol)");
+        assertFalse(validator.isValid("-" + infinity, Locale.US), "isValid(-infinity symbol)");
     }
 
     /**

--- a/src/test/java/org/apache/commons/validator/routines/FloatValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/FloatValidatorTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.util.Locale;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -148,6 +149,20 @@ class FloatValidatorTest extends AbstractNumberValidatorTest {
         final Double tooSmallNegative = Double.valueOf(tooSmallPositive.doubleValue() * -1);
         final String strTooSmallNegative = fmt.format(tooSmallNegative);
         assertFalse(FloatValidator.getInstance().isValid(strTooSmallNegative, pattern), "Too small -ve");
+    }
+
+    /**
+     * Test the locale infinity symbol is rejected. Unlike the "Infinity" string, the symbol parses through to an infinite value, so it is rejected to keep both
+     * paths consistent. NaN is unaffected.
+     */
+    @Test
+    void testFloatValidateInfinitySymbol() {
+        final FloatValidator validator = FloatValidator.getInstance();
+        final String infinity = new DecimalFormatSymbols(Locale.US).getInfinity();
+        assertNull(validator.validate(infinity, Locale.US), "validate(infinity symbol)");
+        assertNull(validator.validate("-" + infinity, Locale.US), "validate(-infinity symbol)");
+        assertFalse(validator.isValid(infinity, Locale.US), "isValid(infinity symbol)");
+        assertFalse(validator.isValid("-" + infinity, Locale.US), "isValid(-infinity symbol)");
     }
 
     /**


### PR DESCRIPTION
reading the number validators, validate of double and float passes the parsed value straight through processParsedValue without checking it is finite. NumberFormat recognises the locale NaN and infinity symbols, so validate("NaN"), validate("∞") and validate("-∞") return NaN/infinity and isValid returns true. a NaN that validates then silently defeats every isInRange/minValue/maxValue check, since NaN compares false against everything. reject non-finite results in both validators.