### PR TITLE
Fix long range check in GenericTypeValidator.formatLong

### DIFF
--- a/src/main/java/org/apache/commons/validator/GenericTypeValidator.java
+++ b/src/main/java/org/apache/commons/validator/GenericTypeValidator.java
@@ -405,10 +405,13 @@ public class GenericTypeValidator implements Serializable {
             final Number num = formatter.parse(value, pos);
 
             // If there was no error      and we used the whole string
+            // NumberFormat returns a Long only when the value fits in a long;
+            // out-of-range input is returned as a Double, so a doubleValue()
+            // range check cannot be used here (Long.MAX_VALUE is not exactly
+            // representable as a double and would let 2^63 through).
             if (pos.getErrorIndex() == -1 && pos.getIndex() == value.length() &&
-                    num.doubleValue() >= Long.MIN_VALUE &&
-                    num.doubleValue() <= Long.MAX_VALUE) {
-                result = Long.valueOf(num.longValue());
+                    num instanceof Long) {
+                result = (Long) num;
             }
         }
 

--- a/src/main/java/org/apache/commons/validator/GenericTypeValidator.java
+++ b/src/main/java/org/apache/commons/validator/GenericTypeValidator.java
@@ -404,13 +404,14 @@ public class GenericTypeValidator implements Serializable {
             final ParsePosition pos = new ParsePosition(0);
             final Number num = formatter.parse(value, pos);
 
-            // If there was no error      and we used the whole string
+            // If we used the whole string and the value fits in a long.
             // NumberFormat returns a Long only when the value fits in a long;
             // out-of-range input is returned as a Double, so a doubleValue()
             // range check cannot be used here (Long.MAX_VALUE is not exactly
-            // representable as a double and would let 2^63 through).
-            if (pos.getErrorIndex() == -1 && pos.getIndex() == value.length() &&
-                    num instanceof Long) {
+            // representable as a double and would let 2^63 through). A failed
+            // parse returns null, so the instanceof check also covers it and
+            // the pos.getErrorIndex() test is no longer needed.
+            if (pos.getIndex() == value.length() && num instanceof Long) {
                 result = (Long) num;
             }
         }

--- a/src/test/java/org/apache/commons/validator/GenericTypeValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/GenericTypeValidatorTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.IOException;
+import java.math.BigInteger;
 import java.util.Date;
 import java.util.Locale;
 import java.util.Map;
@@ -177,11 +178,11 @@ class GenericTypeValidatorTest extends AbstractCommonTest {
      */
     @Test
     void testLongLocaleOverflow() {
-        assertEquals(Long.valueOf(Long.MAX_VALUE), GenericTypeValidator.formatLong("9223372036854775807", Locale.US));
-        assertEquals(Long.valueOf(Long.MIN_VALUE), GenericTypeValidator.formatLong("-9223372036854775808", Locale.US));
+        assertEquals(Long.valueOf(Long.MAX_VALUE), GenericTypeValidator.formatLong(Long.toString(Long.MAX_VALUE), Locale.US));
+        assertEquals(Long.valueOf(Long.MIN_VALUE), GenericTypeValidator.formatLong(Long.toString(Long.MIN_VALUE), Locale.US));
         // Long.MAX_VALUE + 1 and Long.MIN_VALUE - 1 round to the long bounds as a double and used to be accepted.
-        assertNull(GenericTypeValidator.formatLong("9223372036854775808", Locale.US));
-        assertNull(GenericTypeValidator.formatLong("-9223372036854775809", Locale.US));
+        assertNull(GenericTypeValidator.formatLong(BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE).toString(), Locale.US));
+        assertNull(GenericTypeValidator.formatLong(BigInteger.valueOf(Long.MIN_VALUE).subtract(BigInteger.ONE).toString(), Locale.US));
     }
 
     /**

--- a/src/test/java/org/apache/commons/validator/GenericTypeValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/GenericTypeValidatorTest.java
@@ -183,6 +183,8 @@ class GenericTypeValidatorTest extends AbstractCommonTest {
         // Long.MAX_VALUE + 1 and Long.MIN_VALUE - 1 round to the long bounds as a double and used to be accepted.
         assertNull(GenericTypeValidator.formatLong(BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE).toString(), Locale.US));
         assertNull(GenericTypeValidator.formatLong(BigInteger.valueOf(Long.MIN_VALUE).subtract(BigInteger.ONE).toString(), Locale.US));
+        // Trailing characters are only consumed up to the first non-digit, so the whole-string check must reject them.
+        assertNull(GenericTypeValidator.formatLong("123x", Locale.US));
     }
 
     /**

--- a/src/test/java/org/apache/commons/validator/GenericTypeValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/GenericTypeValidatorTest.java
@@ -19,6 +19,7 @@ package org.apache.commons.validator;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.IOException;
 import java.util.Date;
@@ -169,6 +170,18 @@ class GenericTypeValidatorTest extends AbstractCommonTest {
         // assertTrue(ACTION + " value ValidatorResult for the '" + ACTION +"' action should have " + (passed ? "passed" : "failed") + ".", (passed ?
         // result.isValid(ACTION) : !result.isValid(ACTION)));
 
+    }
+
+    /**
+     * Tests that {@link GenericTypeValidator#formatLong(String, Locale)} rejects values just outside the long range instead of clamping them.
+     */
+    @Test
+    void testLongLocaleOverflow() {
+        assertEquals(Long.valueOf(Long.MAX_VALUE), GenericTypeValidator.formatLong("9223372036854775807", Locale.US));
+        assertEquals(Long.valueOf(Long.MIN_VALUE), GenericTypeValidator.formatLong("-9223372036854775808", Locale.US));
+        // Long.MAX_VALUE + 1 and Long.MIN_VALUE - 1 round to the long bounds as a double and used to be accepted.
+        assertNull(GenericTypeValidator.formatLong("9223372036854775808", Locale.US));
+        assertNull(GenericTypeValidator.formatLong("-9223372036854775809", Locale.US));
     }
 
     /**


### PR DESCRIPTION
While going over the numeric format helpers I noticed formatLong(String, Locale) range-checks the parsed number with num.doubleValue() against Long.MIN_VALUE and Long.MAX_VALUE. Long.MAX_VALUE is not exactly representable as a double, so it is promoted to 2^63 in that comparison. Parsing "9223372036854775808" (Long.MAX_VALUE + 1), which NumberFormat returns as a Double that rounds to 2^63, then satisfies the upper bound and is accepted; longValue() afterwards clamps it back to Long.MAX_VALUE, so the helper reports a value the caller never entered. "-9223372036854775809" behaves the same way at the lower bound. The root cause is using a lossy double comparison to decide whether an integral value fits in a long.

The fix accepts the result only when NumberFormat hands back a Long, which it does exactly when the value fits in a long; anything out of range comes back as a Double and is now rejected. This matches what routines.LongValidator already does and keeps the bounds decision inside the conversion routine instead of leaving callers to second-guess a silently clamped result. Left unfixed this lets out-of-range input pass validation and corrupt the converted value. The other format* methods are untouched because their int/short/byte bounds are exact as doubles, so the same rounding gap does not arise.