### PR TITLE
DoubleValidator and FloatValidator now treat special symbols consistently

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/DoubleValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/DoubleValidator.java
@@ -197,7 +197,6 @@ public class DoubleValidator extends AbstractNumberValidator {
             return value;
         }
         return Double.valueOf(((Number) value).doubleValue());
-
     }
 
     /**

--- a/src/main/java/org/apache/commons/validator/routines/FloatValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/FloatValidator.java
@@ -194,22 +194,24 @@ public class FloatValidator extends AbstractNumberValidator {
      */
     @Override
     protected Object processParsedValue(final Object value, final Format formatter) {
-
-        final double doubleValue = ((Number) value).doubleValue();
-
+        final double doubleValue = value instanceof Double ? (Double) value : Double.valueOf(((Number) value).doubleValue());
         if (doubleValue > 0) {
+            if (doubleValue == Double.POSITIVE_INFINITY) {
+                return Float.POSITIVE_INFINITY;
+            }
             if (doubleValue < Float.MIN_VALUE || doubleValue > Float.MAX_VALUE) {
                 return null;
             }
         } else if (doubleValue < 0) {
+            if (doubleValue == Double.NEGATIVE_INFINITY) {
+                return Float.NEGATIVE_INFINITY;
+            }
             final double posDouble = doubleValue * -1;
             if (posDouble < Float.MIN_VALUE || posDouble > Float.MAX_VALUE) {
                 return null;
             }
         }
-
         return Float.valueOf((float) doubleValue);
-
     }
 
     /**

--- a/src/test/java/org/apache/commons/validator/routines/DoubleValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/DoubleValidatorTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.text.DecimalFormatSymbols;
 import java.util.Locale;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -34,6 +35,10 @@ import org.junit.jupiter.api.condition.JRE;
  * Tests {@link DoubleValidator}.
  */
 class DoubleValidatorTest extends AbstractNumberValidatorTest {
+
+    private static final String NEGATIVE_INFINITY_STRING = Double.toString(Double.NEGATIVE_INFINITY);
+    private static final String POSITIVE_INFINITY_STRING = Double.toString(Double.POSITIVE_INFINITY);
+    private static final String NAN_STRING = Double.toString(Double.NaN);
 
     @BeforeEach
     protected void setUp() {
@@ -128,46 +133,6 @@ class DoubleValidatorTest extends AbstractNumberValidatorTest {
     }
 
     /**
-     * Test DoubleValidator.validate(String) with Double special values. NumberFormat.parseObject("NaN") succeeds and returns Double.NaN, but "Infinity" and
-     * "-Infinity" cause a parse error and return null.
-     */
-    @Test
-    @EnabledForJreRange(min = JRE.JAVA_11)
-    void testDoubleValidateSpecialValuesJava11Plus() {
-        final DoubleValidator validator = DoubleValidator.getInstance();
-        // Double.NaN -> "NaN": NumberFormat parses "NaN" successfully
-        final Double nanResult = validator.validate(Double.toString(Double.NaN));
-        assertTrue(Double.isNaN(nanResult), "validate(\"NaN\") should return Double.NaN");
-        assertTrue(validator.isValid(Double.toString(Double.NaN)), "isValid(\"NaN\") should be true");
-        // Double.POSITIVE_INFINITY -> "Infinity": NumberFormat cannot parse "Infinity"
-        assertNull(validator.validate(Double.toString(Double.POSITIVE_INFINITY)));
-        assertFalse(validator.isValid(Double.toString(Double.POSITIVE_INFINITY)));
-        // Double.NEGATIVE_INFINITY -> "-Infinity": NumberFormat cannot parse "-Infinity"
-        assertNull(validator.validate(Double.toString(Double.NEGATIVE_INFINITY)));
-        assertFalse(validator.isValid(Double.toString(Double.NEGATIVE_INFINITY)));
-    }
-
-    /**
-     * Test DoubleValidator.validate(String) with Double special values. NumberFormat.parseObject("NaN") succeeds and returns Double.NaN, but "Infinity" and
-     * "-Infinity" cause a parse error and return null.
-     */
-    @Test
-    @EnabledOnJre(JRE.JAVA_8)
-    void testDoubleValidateSpecialValuesJava8() {
-        final DoubleValidator validator = DoubleValidator.getInstance();
-        // Double.NaN -> "NaN": NumberFormat parses "NaN" successfully
-        final Double nanResult = validator.validate(Double.toString(Double.NaN));
-        assertNull(nanResult);
-        assertFalse(validator.isValid(Double.toString(Double.NaN)), "isValid(\"NaN\") should be true");
-        // Double.POSITIVE_INFINITY -> "Infinity": NumberFormat cannot parse "Infinity"
-        assertNull(validator.validate(Double.toString(Double.POSITIVE_INFINITY)));
-        assertFalse(validator.isValid(Double.toString(Double.POSITIVE_INFINITY)));
-        // Double.NEGATIVE_INFINITY -> "-Infinity": NumberFormat cannot parse "-Infinity"
-        assertNull(validator.validate(Double.toString(Double.NEGATIVE_INFINITY)));
-        assertFalse(validator.isValid(Double.toString(Double.NEGATIVE_INFINITY)));
-    }
-
-    /**
      * Test DoubleValidator validate Methods
      */
     @Test
@@ -197,5 +162,59 @@ class DoubleValidatorTest extends AbstractNumberValidatorTest {
         assertFalse(validator.isValid(xxxx, locale), "isValid(B) locale");
         assertFalse(validator.isValid(xxxx, pattern), "isValid(B) pattern");
         assertFalse(validator.isValid(patternVal, pattern, Locale.GERMAN), "isValid(B) both");
+    }
+
+    @Test
+    void testSpecialSymbols() {
+        final DoubleValidator validator = DoubleValidator.getInstance();
+        // Double.NaN -> "NaN": NumberFormat parses "NaN" successfully
+        // Double.POSITIVE_INFINITY -> "Infinity": NumberFormat cannot parse "Infinity"
+        assertNull(validator.validate(POSITIVE_INFINITY_STRING));
+        assertFalse(validator.isValid(POSITIVE_INFINITY_STRING));
+        // Double.NEGATIVE_INFINITY -> "-Infinity": NumberFormat cannot parse "-Infinity"
+        assertNull(validator.validate(NEGATIVE_INFINITY_STRING));
+        assertFalse(validator.isValid(NEGATIVE_INFINITY_STRING));
+        // infinity is "∞" for Locale.US.
+        final String infinity = new DecimalFormatSymbols(Locale.US).getInfinity();
+        assertEquals(Double.POSITIVE_INFINITY, validator.validate(infinity, Locale.US));
+        assertEquals(Double.NEGATIVE_INFINITY, validator.validate("-" + infinity, Locale.US));
+        assertTrue(validator.isValid(infinity, Locale.US));
+        assertTrue(validator.isValid("-" + infinity, Locale.US));
+        //
+        // Double.POSITIVE_INFINITY -> "Infinity": NumberFormat cannot parse "Infinity"
+        assertNull(validator.validate(POSITIVE_INFINITY_STRING));
+        assertFalse(validator.isValid(POSITIVE_INFINITY_STRING));
+        // Double.NEGATIVE_INFINITY -> "-Infinity": NumberFormat cannot parse "-Infinity"
+        assertNull(validator.validate(NEGATIVE_INFINITY_STRING));
+        assertFalse(validator.isValid(NEGATIVE_INFINITY_STRING));
+    }
+
+    /**
+     * Test DoubleValidator.validate(String) with Double special values. NumberFormat.parseObject("NaN") succeeds and returns Double.NaN, but "Infinity" and
+     * "-Infinity" cause a parse error and return null.
+     */
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_11)
+    void testSpecialSymbolsJava11Plus() {
+        final DoubleValidator validator = DoubleValidator.getInstance();
+        // Double.NaN -> "NaN": NumberFormat parses "NaN" successfully
+        final Double nanResult = validator.validate(NAN_STRING);
+        assertTrue(Double.isNaN(nanResult));
+        assertTrue(validator.isValid(NAN_STRING, Locale.US));
+        assertTrue(validator.isValid(NAN_STRING));
+    }
+
+    /**
+     * Test DoubleValidator.validate(String) with Double special values. NumberFormat.parseObject("NaN") succeeds and returns Double.NaN, but "Infinity" and
+     * "-Infinity" cause a parse error and return null.
+     */
+    @Test
+    @EnabledOnJre(JRE.JAVA_8)
+    void testSpecialSymbolsJava8() {
+        final DoubleValidator validator = DoubleValidator.getInstance();
+        final Double nanResult = validator.validate(NAN_STRING);
+        assertNull(nanResult);
+        assertFalse(validator.isValid(NAN_STRING, Locale.US));
+        assertFalse(validator.isValid(NAN_STRING));
     }
 }

--- a/src/test/java/org/apache/commons/validator/routines/FloatValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/FloatValidatorTest.java
@@ -20,18 +20,29 @@ package org.apache.commons.validator.routines;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
+import java.text.NumberFormat;
+import java.text.ParseException;
 import java.util.Locale;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledForJreRange;
+import org.junit.jupiter.api.condition.EnabledOnJre;
+import org.junit.jupiter.api.condition.JRE;
 
 /**
  * Tests {@link FloatValidator}.
  */
 class FloatValidatorTest extends AbstractNumberValidatorTest {
+
+    private static final String NAN_STRING = Float.toString(Float.NaN);
+    private static final String NEGATIVE_INFINITY_STRING = Float.toString(Float.NEGATIVE_INFINITY);
+    private static final String POSITIVE_INFINITY_STRING = Float.toString(Float.POSITIVE_INFINITY);
 
     @BeforeEach
     protected void setUp() {
@@ -180,5 +191,50 @@ class FloatValidatorTest extends AbstractNumberValidatorTest {
         assertFalse(validator.isValid(xxxx, locale), "isValid(B) locale");
         assertFalse(validator.isValid(xxxx, pattern), "isValid(B) pattern");
         assertFalse(validator.isValid(patternVal, pattern, Locale.GERMAN), "isValid(B) both");
+    }
+
+    @Test
+    void testSpecialSymbols() {
+        final FloatValidator validator = FloatValidator.getInstance();
+        // Double.NaN -> "NaN": NumberFormat parses "NaN" successfully
+        // Double.POSITIVE_INFINITY -> "Infinity": NumberFormat cannot parse "Infinity"
+        assertNull(validator.validate(POSITIVE_INFINITY_STRING));
+        assertFalse(validator.isValid(POSITIVE_INFINITY_STRING));
+        // Double.NEGATIVE_INFINITY -> "-Infinity": NumberFormat cannot parse "-Infinity"
+        assertNull(validator.validate(NEGATIVE_INFINITY_STRING));
+        assertFalse(validator.isValid(NEGATIVE_INFINITY_STRING));
+        // infinity is "∞" for Locale.US.
+        final String infinity = new DecimalFormatSymbols(Locale.US).getInfinity();
+        assertEquals(Float.POSITIVE_INFINITY, validator.validate(infinity, Locale.US));
+        assertEquals(Float.NEGATIVE_INFINITY, validator.validate("-" + infinity, Locale.US));
+        assertTrue(validator.isValid(infinity, Locale.US));
+        assertTrue(validator.isValid("-" + infinity, Locale.US));
+        //
+        // Double.POSITIVE_INFINITY -> "Infinity": NumberFormat cannot parse "Infinity"
+        assertNull(validator.validate(POSITIVE_INFINITY_STRING));
+        assertFalse(validator.isValid(POSITIVE_INFINITY_STRING));
+        // Double.NEGATIVE_INFINITY -> "-Infinity": NumberFormat cannot parse "-Infinity"
+        assertNull(validator.validate(NEGATIVE_INFINITY_STRING));
+        assertFalse(validator.isValid(NEGATIVE_INFINITY_STRING));
+    }
+
+    @Test
+    @EnabledForJreRange(min = JRE.JAVA_11)
+    void testSpecialSymbolsJava11Plus() throws ParseException {
+        // JRE check:
+        assertTrue(Double.isNaN(NumberFormat.getInstance(Locale.US).parse(NAN_STRING).doubleValue()));
+        // Ours:
+        final FloatValidator validator = FloatValidator.getInstance();
+        assertTrue(validator.isValid(NAN_STRING, Locale.US));
+    }
+
+    @Test
+    @EnabledOnJre(JRE.JAVA_8)
+    void testSpecialSymbolsJava8() {
+        // JRE check
+        assertThrows(ParseException.class, () -> NumberFormat.getInstance(Locale.US).parse(NAN_STRING));
+        // Ours:
+        final FloatValidator validator = FloatValidator.getInstance();
+        assertFalse(validator.isValid(NAN_STRING, Locale.US));
     }
 }

--- a/src/test/java/org/apache/commons/validator/routines/checkdigit/CheckDigitNonAsciiDigitTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/checkdigit/CheckDigitNonAsciiDigitTest.java
@@ -27,13 +27,16 @@ import org.junit.jupiter.api.Test;
  */
 class CheckDigitNonAsciiDigitTest {
 
-    private static String toFullwidth(final String code) {
-        final StringBuilder sb = new StringBuilder(code.length());
-        for (int i = 0; i < code.length(); i++) {
-            final char c = code.charAt(i);
-            sb.append(c >= '0' && c <= '9' ? (char) ('０' + (c - '0')) : c);
+    private static void assertRejectsNonAscii(final CheckDigit routine, final String validCode) {
+        assertTrue(routine.isValid(validCode), "ASCII: " + validCode);
+        assertFalse(routine.isValid(toFullwidth(validCode)), "fullwidth: " + validCode);
+        assertFalse(routine.isValid(toArabicIndic(validCode)), "arabic-indic: " + validCode);
+        for (char i = 0; i < 32; i++) {
+            assertFalse(routine.isValid(validCode.replaceFirst("[a-zA-Z0-9]", Character.valueOf(i).toString())), validCode);
         }
-        return sb.toString();
+        for (char i = 127; i < 256; i++) {
+            assertFalse(routine.isValid(validCode.replaceFirst("[a-zA-Z0-9]", Character.valueOf(i).toString())), validCode);
+        }
     }
 
     private static String toArabicIndic(final String code) {
@@ -45,16 +48,13 @@ class CheckDigitNonAsciiDigitTest {
         return sb.toString();
     }
 
-    private static void assertRejectsNonAscii(final CheckDigit routine, final String validCode) {
-        assertTrue(routine.isValid(validCode), "ASCII: " + validCode);
-        assertFalse(routine.isValid(toFullwidth(validCode)), "fullwidth: " + validCode);
-        assertFalse(routine.isValid(toArabicIndic(validCode)), "arabic-indic: " + validCode);
-        for (char i = 0; i < 32; i++) {
-            assertFalse(routine.isValid(validCode.replaceFirst("[a-zA-Z0-9]", Character.valueOf(i).toString())), validCode);
+    private static String toFullwidth(final String code) {
+        final StringBuilder sb = new StringBuilder(code.length());
+        for (int i = 0; i < code.length(); i++) {
+            final char c = code.charAt(i);
+            sb.append(c >= '0' && c <= '9' ? (char) ('０' + (c - '0')) : c);
         }
-        for (char i = 127; i < 256; i++) {
-            assertFalse(routine.isValid(validCode.replaceFirst("[a-zA-Z0-9]", Character.valueOf(i).toString())), validCode);
-        }
+        return sb.toString();
     }
 
     @Test
@@ -68,13 +68,13 @@ class CheckDigitNonAsciiDigitTest {
     }
 
     @Test
-    void testISIN() {
-        assertRejectsNonAscii(ISINCheckDigit.ISIN_CHECK_DIGIT, "US0378331005");
+    void testISBN10() {
+        assertRejectsNonAscii(ISBN10CheckDigit.ISBN10_CHECK_DIGIT, "1930110995");
     }
 
     @Test
-    void testISBN10() {
-        assertRejectsNonAscii(ISBN10CheckDigit.ISBN10_CHECK_DIGIT, "1930110995");
+    void testISIN() {
+        assertRejectsNonAscii(ISINCheckDigit.ISIN_CHECK_DIGIT, "US0378331005");
     }
 
     @Test


### PR DESCRIPTION
`DoubleValidator` and `FloatValidator` now treat special symbols consistently (NaN, +/- infinity).

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] ~~I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?~~
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
