### PR TITLE
fix BigIntegerValidator clamping values above Long.MAX_VALUE

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/BigIntegerValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/BigIntegerValidator.java
@@ -158,8 +158,6 @@ public class BigIntegerValidator extends AbstractNumberValidator {
      */
     @Override
     protected Object processParsedValue(final Object value, final Format formatter) {
-        // A value that fits in a long is parsed as a Long; anything larger comes back as a
-        // Double, whose longValue() saturates at Long.MAX_VALUE and loses the magnitude.
         if (value instanceof Long) {
             return BigInteger.valueOf(((Long) value).longValue());
         }

--- a/src/main/java/org/apache/commons/validator/routines/BigIntegerValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/BigIntegerValidator.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.validator.routines;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.text.Format;
 import java.text.NumberFormat;
@@ -157,7 +158,12 @@ public class BigIntegerValidator extends AbstractNumberValidator {
      */
     @Override
     protected Object processParsedValue(final Object value, final Format formatter) {
-        return BigInteger.valueOf(((Number) value).longValue());
+        // A value that fits in a long is parsed as a Long; anything larger comes back as a
+        // Double, whose longValue() saturates at Long.MAX_VALUE and loses the magnitude.
+        if (value instanceof Long) {
+            return BigInteger.valueOf(((Long) value).longValue());
+        }
+        return new BigDecimal(value.toString()).toBigInteger();
     }
 
     /**

--- a/src/test/java/org/apache/commons/validator/routines/BigIntegerValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/BigIntegerValidatorTest.java
@@ -150,4 +150,5 @@ class BigIntegerValidatorTest extends AbstractNumberValidatorTest {
         assertFalse(BigIntegerValidator.getInstance().isInRange(result, Long.MIN_VALUE, Long.MAX_VALUE), "isInRange should fail for values > Long.MAX_VALUE");
         // BigDecimalValidator already preserves the magnitude, so the two must agree
         assertEquals(BigDecimalValidator.getInstance().validate(input, "#").toBigInteger(), result);
+    }
 }

--- a/src/test/java/org/apache/commons/validator/routines/BigIntegerValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/BigIntegerValidatorTest.java
@@ -146,7 +146,8 @@ class BigIntegerValidatorTest extends AbstractNumberValidatorTest {
         final String input = aboveLong.toString();
         final BigInteger result = BigIntegerValidator.getInstance().validate(input, "#");
         assertTrue(result.compareTo(BigInteger.valueOf(Long.MAX_VALUE)) > 0, "value clamped to Long.MAX_VALUE");
+        assertFalse(BigIntegerValidator.getInstance().maxValue(result, Long.MAX_VALUE), "maxValue should fail for values > Long.MAX_VALUE");
+        assertFalse(BigIntegerValidator.getInstance().isInRange(result, Long.MIN_VALUE, Long.MAX_VALUE), "isInRange should fail for values > Long.MAX_VALUE");
         // BigDecimalValidator already preserves the magnitude, so the two must agree
         assertEquals(BigDecimalValidator.getInstance().validate(input, "#").toBigInteger(), result);
-    }
 }

--- a/src/test/java/org/apache/commons/validator/routines/BigIntegerValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/BigIntegerValidatorTest.java
@@ -141,11 +141,12 @@ class BigIntegerValidatorTest extends AbstractNumberValidatorTest {
      */
     @Test
     void testBigIntegerAboveLongMaxValue() {
-        final String aboveLong = "99999999999999999999999999"; // far beyond Long.MAX_VALUE
-        final BigInteger result = BigIntegerValidator.getInstance().validate(aboveLong, "#");
+        // One past Long.MAX_VALUE, so NumberFormat parses it as a Double rather than a Long.
+        final BigInteger aboveLong = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);
+        final String input = aboveLong.toString();
+        final BigInteger result = BigIntegerValidator.getInstance().validate(input, "#");
         assertTrue(result.compareTo(BigInteger.valueOf(Long.MAX_VALUE)) > 0, "value clamped to Long.MAX_VALUE");
-        assertEquals(new BigInteger("100000000000000000000000000"), result);
         // BigDecimalValidator already preserves the magnitude, so the two must agree
-        assertEquals(BigDecimalValidator.getInstance().validate(aboveLong, "#").toBigInteger(), result);
+        assertEquals(BigDecimalValidator.getInstance().validate(input, "#").toBigInteger(), result);
     }
 }

--- a/src/test/java/org/apache/commons/validator/routines/BigIntegerValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/BigIntegerValidatorTest.java
@@ -134,4 +134,18 @@ class BigIntegerValidatorTest extends AbstractNumberValidatorTest {
         assertFalse(BigIntegerValidator.getInstance().isValid(xxxx, pattern), "isValid(B) pattern");
         assertFalse(BigIntegerValidator.getInstance().isValid(patternVal, pattern, Locale.GERMAN), "isValid(B) both");
     }
+
+    /**
+     * Test a value larger than {@link Long#MAX_VALUE} keeps its magnitude instead of being
+     * clamped to {@link Long#MAX_VALUE}.
+     */
+    @Test
+    void testBigIntegerAboveLongMaxValue() {
+        final String aboveLong = "99999999999999999999999999"; // far beyond Long.MAX_VALUE
+        final BigInteger result = BigIntegerValidator.getInstance().validate(aboveLong, "#");
+        assertTrue(result.compareTo(BigInteger.valueOf(Long.MAX_VALUE)) > 0, "value clamped to Long.MAX_VALUE");
+        assertEquals(new BigInteger("100000000000000000000000000"), result);
+        // BigDecimalValidator already preserves the magnitude, so the two must agree
+        assertEquals(BigDecimalValidator.getInstance().validate(aboveLong, "#").toBigInteger(), result);
+    }
 }


### PR DESCRIPTION
BigIntegerValidator.validate runs the input through NumberFormat, which returns a Long while the number fits in a long and switches to a Double once it overflows. processParsedValue then converts via longValue(), and on a Double that saturates at Long.MAX_VALUE, so "99999999999999999999999999" comes back as 9223372036854775807 with no exception or warning to flag it. I caught this lining the integer validators up against each other: BigDecimalValidator routes the same parsed Double through its string form and keeps the magnitude, while BigIntegerValidator throws it away.

Sending the non-Long branch through the parsed value's string form mirrors what BigDecimalValidator already does, so the two stay consistent on oversized input. Keeping the conversion inside processParsedValue covers every validate and isValid entry point without touching the shared parsing code. Left alone the behaviour is a quiet correctness hole: folding every large value onto one fixed number lets a later maxValue or range check pass for inputs the real number should fail.
