### PR TITLE
Fix RegexValidator.validate() returning null for a valid match

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/RegexValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/RegexValidator.java
@@ -233,7 +233,8 @@ public class RegexValidator implements Serializable {
             if (matcher.matches()) {
                 final int count = matcher.groupCount();
                 if (count == 1) {
-                    return matcher.group(1);
+                    final String group = matcher.group(1);
+                    return group != null ? group : "";
                 }
                 final StringBuilder buffer = new StringBuilder();
                 for (int j = 0; j < count; j++) {

--- a/src/test/java/org/apache/commons/validator/routines/RegexValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/RegexValidatorTest.java
@@ -223,6 +223,19 @@ class RegexValidatorTest {
     }
 
     /**
+     * Test that validate() is consistent with isValid() and match() when the only
+     * capturing group is optional and does not participate in the match. The value
+     * is valid, so validate() must not return null (which signals an invalid value).
+     */
+    @Test
+    void testValidateOptionalGroup() {
+        final RegexValidator validator = new RegexValidator("^(abc)?def$");
+        assertTrue(validator.isValid("def"), "isValid()");
+        checkArray("match()", new String[] { null }, validator.match("def"));
+        assertEquals("", validator.validate("def"), "validate()");
+    }
+
+    /**
      * Test toString() method
      */
     @Test


### PR DESCRIPTION
Thanks for your contribution to Apache Commons!

- [x] Read the contribution guidelines for this project.
- [ ] Read the ASF Generative Tooling Guidance if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [ ] Run a successful build using the default Maven goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.

`RegexValidator.validate` has a single capturing group fast path that returns `matcher.group(1)` directly. When the sole group is optional and does not take part in the match, for example `new RegexValidator("^(abc)?def$")` against `"def"`, that group is null and so `validate` hands back null. I came across this while tracing why the three public methods disagreed on one input: `isValid` returns true, `match` returns a one element array holding null, yet `validate` returns null, which its own Javadoc reserves for an invalid value.

The multi group path already skips null groups and aggregates to an empty string, so the defect is confined to the `count == 1` branch. I have made that branch fall back to an empty string when the group is absent, which lines up with the aggregation behaviour and the documented contract. Left alone, any caller that reads a null from `validate` as a rejection silently drops valid input, and because `isValid` still reports the value as good the mismatch is easy to miss. The added test exercises the optional group case and fails on the current code.
