### PR TITLE
Compare CAS and EC check digit against validated code, not raw input

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigit.java
@@ -110,9 +110,10 @@ public final class CASNumberCheckDigit extends ModulusCheckDigit {
         if (!(cde instanceof String)) {
             return false;
         }
+        final String validated = (String) cde;
         try {
-            final int modulusResult = INSTANCE.calculateModulus((String) cde, true);
-            return modulusResult == Character.getNumericValue(code.charAt(code.length() - 1));
+            final int modulusResult = INSTANCE.calculateModulus(validated, true);
+            return modulusResult == Character.getNumericValue(validated.charAt(validated.length() - 1));
         } catch (final CheckDigitException ex) {
             return false;
         }

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigit.java
@@ -98,9 +98,10 @@ public final class ECNumberCheckDigit extends ModulusCheckDigit {
         if (!(cde instanceof String)) {
             return false;
         }
+        final String validated = (String) cde;
         try {
-            final int modulusResult = INSTANCE.calculateModulus((String) cde, true);
-            return modulusResult == Character.getNumericValue(code.charAt(code.length() - 1));
+            final int modulusResult = INSTANCE.calculateModulus(validated, true);
+            return modulusResult == Character.getNumericValue(validated.charAt(validated.length() - 1));
         } catch (final CheckDigitException ex) {
             return false;
         }

--- a/src/test/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigitTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/checkdigit/CASNumberCheckDigitTest.java
@@ -16,7 +16,10 @@
  */
 package org.apache.commons.validator.routines.checkdigit;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * CAS Number Check Digit Tests.
@@ -53,6 +56,15 @@ class CASNumberCheckDigitTest extends AbstractCheckDigitTest {
     protected void setUp() {
         routine = CASNumberCheckDigit.getInstance();
         valid = new String[] {MIN, WATER, ETHANOL, ASPIRIN, COFFEIN, FORMALDEHYDE, DEXAMETHASONE, ARSENIC, ASBESTOS, MAX};
+    }
+
+    /**
+     * The format validator trims the input, so surrounding whitespace must not change the result.
+     */
+    @Test
+    void testIsValidSurroundingWhitespace() {
+        assertTrue(routine.isValid(" " + WATER), "leading whitespace");
+        assertTrue(routine.isValid(WATER + " "), "trailing whitespace");
     }
 
 }

--- a/src/test/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigitTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/checkdigit/ECNumberCheckDigitTest.java
@@ -16,7 +16,10 @@
  */
 package org.apache.commons.validator.routines.checkdigit;
 
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 /**
  * EC Number Check Digit Tests.
@@ -49,6 +52,15 @@ class ECNumberCheckDigitTest extends AbstractCheckDigitTest {
     protected void setUp() {
         routine = ECNumberCheckDigit.getInstance();
         valid = new String[] {MIN, FORMALDEHYDE, DEXAMETHASONE, ARSENIC, ASBESTOS, MAX};
+    }
+
+    /**
+     * The format validator trims the input, so surrounding whitespace must not change the result.
+     */
+    @Test
+    void testIsValidSurroundingWhitespace() {
+        assertTrue(routine.isValid(" " + DEXAMETHASONE), "leading whitespace");
+        assertTrue(routine.isValid(DEXAMETHASONE + " "), "trailing whitespace");
     }
 
 }


### PR DESCRIPTION
Both `CASNumberCheckDigit.isValid` and `ECNumberCheckDigit.isValid` pass the argument through `REGEX_VALIDATOR`, which is a `CodeValidator` and so trims the input and drops the dash separators before matching. The check digit is then read back from `code.charAt(code.length() - 1)` on the untouched argument. I tripped over this feeding values from a data column that still had trailing spaces: `"7732-18-5 "` is rejected while `" 7732-18-5"` passes, so validity ends up depending on which side a stray space happens to sit.

The string returned by the validator is already trimmed and de-formatted, and its last character is the check digit, so the comparison belongs on that value rather than the raw argument. Reading both the modulus input and the check digit from the validated string removes the asymmetry and keeps the two routines consistent with the trimming the format validator already does everywhere else. Left as is, valid CAS and EC numbers are quietly rejected whenever the caller has not stripped trailing whitespace first.

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
