### PR TITLE
Fix ISIN country-code check using untrimmed input

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/ISINValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/ISINValidator.java
@@ -460,11 +460,7 @@ public class ISINValidator implements Serializable {
      * code, otherwise {@code false}.
      */
     public boolean isValid(final String code) {
-        final boolean valid = VALIDATOR.isValid(code);
-        if (valid && checkCountryCode) {
-            return checkCode(code.substring(0, 2));
-        }
-        return valid;
+        return validate(code) != null;
     }
 
     /**
@@ -476,7 +472,7 @@ public class ISINValidator implements Serializable {
     public Object validate(final String code) {
         final Object validate = VALIDATOR.validate(code);
         if (validate != null && checkCountryCode) {
-            return checkCode(code.substring(0, 2)) ? validate : null;
+            return checkCode(validate.toString().substring(0, 2)) ? validate : null;
         }
         return validate;
     }

--- a/src/test/java/org/apache/commons/validator/routines/ISINValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/ISINValidatorTest.java
@@ -16,6 +16,7 @@
  */
 package org.apache.commons.validator.routines;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -108,6 +109,17 @@ class ISINValidatorTest {
         for (final String f : validFormat) {
             assertTrue(VALIDATOR_TRUE.isValid(f), f);
         }
+    }
+
+    @Test
+    void testValidWithSurroundingWhitespaceCountryCode() {
+        // The underlying CodeValidator trims the input, so the country code must be
+        // derived from the trimmed code. Otherwise a valid ISIN with leading whitespace
+        // is accepted without the country check but rejected with it.
+        final String leading = " US0378331005";
+        assertTrue(VALIDATOR_FALSE.isValid(leading), leading);
+        assertTrue(VALIDATOR_TRUE.isValid(leading), leading);
+        assertEquals("US0378331005", VALIDATOR_TRUE.validate(leading));
     }
 
 }

--- a/src/test/java/org/apache/commons/validator/routines/ISINValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/ISINValidatorTest.java
@@ -114,12 +114,13 @@ class ISINValidatorTest {
     @Test
     void testValidWithSurroundingWhitespaceCountryCode() {
         // The underlying CodeValidator trims the input, so the country code must be
-        // derived from the trimmed code. Otherwise a valid ISIN with leading whitespace
+        // derived from the trimmed code. Otherwise a valid ISIN with surrounding whitespace
         // is accepted without the country check but rejected with it.
-        final String leading = " US0378331005";
-        assertTrue(VALIDATOR_FALSE.isValid(leading), leading);
-        assertTrue(VALIDATOR_TRUE.isValid(leading), leading);
-        assertEquals("US0378331005", VALIDATOR_TRUE.validate(leading));
+        for (final String code : new String[] { " US0378331005", "US0378331005 ", " US0378331005 " }) {
+            assertTrue(VALIDATOR_FALSE.isValid(code), code);
+            assertTrue(VALIDATOR_TRUE.isValid(code), code);
+            assertEquals("US0378331005", VALIDATOR_TRUE.validate(code), code);
+        }
     }
 
 }

--- a/src/test/java/org/apache/commons/validator/routines/ISINValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/ISINValidatorTest.java
@@ -21,6 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * Tests {@link ISINValidator}.
@@ -111,16 +113,15 @@ class ISINValidatorTest {
         }
     }
 
-    @Test
-    void testValidWithSurroundingWhitespaceCountryCode() {
+    @ParameterizedTest
+    @ValueSource(strings = { " US0378331005", "US0378331005 ", " US0378331005 " })
+    void testValidWithSurroundingWhitespaceCountryCode(final String code) {
         // The underlying CodeValidator trims the input, so the country code must be
         // derived from the trimmed code. Otherwise a valid ISIN with surrounding whitespace
         // is accepted without the country check but rejected with it.
-        for (final String code : new String[] { " US0378331005", "US0378331005 ", " US0378331005 " }) {
-            assertTrue(VALIDATOR_FALSE.isValid(code), code);
-            assertTrue(VALIDATOR_TRUE.isValid(code), code);
-            assertEquals("US0378331005", VALIDATOR_TRUE.validate(code), code);
-        }
+        assertTrue(VALIDATOR_FALSE.isValid(code), code);
+        assertTrue(VALIDATOR_TRUE.isValid(code), code);
+        assertEquals("US0378331005", VALIDATOR_TRUE.validate(code), code);
     }
 
 }


### PR DESCRIPTION
**ISIN country code read from the raw argument**

Whilst checking the country-code path I noticed that `isValid`/`validate` disagree with the underlying `CodeValidator` for inputs with surrounding whitespace. The validator trims the argument before matching, so `validate(" US0378331005")` returns the trimmed `US0378331005`, but the ISO-3166 lookup then takes `code.substring(0, 2)` from the original untrimmed string and reads `" U"`, which is not a country code. The upshot is that the same valid ISIN passes with `getInstance(false)` yet is rejected by `getInstance(true)`.

The root cause is the country code being derived from the raw argument rather than from the code the validator actually accepted. Reading it from the validated value keeps both code paths consistent. Left unfixed, callers that enable the country check silently reject otherwise-valid codes purely on the presence of leading whitespace. Added a regression test for the trimmed lookup.