### PR TITLE
Use compareTo() in BigIntegerValidator.minValue()

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/BigIntegerValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/BigIntegerValidator.java
@@ -145,7 +145,7 @@ public class BigIntegerValidator extends AbstractNumberValidator {
      *         or equal to the minimum.
      */
     public boolean minValue(final BigInteger value, final long min) {
-        return value.longValue() >= min;
+        return value.compareTo(BigInteger.valueOf(min)) >= 0;
     }
 
     /**

--- a/src/test/java/org/apache/commons/validator/routines/BigIntegerValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/BigIntegerValidatorTest.java
@@ -84,7 +84,7 @@ class BigIntegerValidatorTest extends AbstractNumberValidatorTest {
         assertTrue(resultAboveLong.compareTo(BigInteger.ZERO) > 0);
         assertTrue(resultAboveLong.compareTo(BigInteger.valueOf(Long.MAX_VALUE)) > 0);
         assertTrue(instance.minValue(resultAboveLong, Long.MIN_VALUE));
-        assertFalse(instance.minValue(resultAboveLong, Long.MAX_VALUE));
+        assertTrue(instance.minValue(resultAboveLong, Long.MAX_VALUE));
         assertFalse(instance.maxValue(resultAboveLong, Long.MIN_VALUE));
         assertFalse(instance.maxValue(resultAboveLong, Long.MAX_VALUE));
         assertFalse(instance.isInRange(resultAboveLong, Long.MIN_VALUE, Long.MAX_VALUE));
@@ -105,13 +105,29 @@ class BigIntegerValidatorTest extends AbstractNumberValidatorTest {
         assertTrue(resultBelowLong.compareTo(BigInteger.valueOf(Long.MIN_VALUE)) < 0);
         assertTrue(resultBelowLong.compareTo(BigInteger.ZERO) < 0);
         assertTrue(resultBelowLong.compareTo(BigInteger.valueOf(Long.MAX_VALUE)) < 0);
-        assertTrue(instance.minValue(resultBelowLong, Long.MIN_VALUE));
+        assertFalse(instance.minValue(resultBelowLong, Long.MIN_VALUE));
         assertFalse(instance.minValue(resultBelowLong, Long.MAX_VALUE));
         assertTrue(instance.maxValue(resultBelowLong, Long.MIN_VALUE));
         assertTrue(instance.maxValue(resultBelowLong, Long.MAX_VALUE));
         assertFalse(instance.isInRange(resultBelowLong, Long.MIN_VALUE, Long.MAX_VALUE));
         // BigDecimalValidator already preserves the magnitude, so the two must agree
         assertEquals(BigDecimalValidator.getInstance().validate(belowLongStr, "#").toBigInteger(), resultBelowLong);
+    }
+
+    /**
+     * Test minValue() against bounds for values outside the long range, using exact BigIntegers so the comparison is not affected by double rounding.
+     */
+    @Test
+    void testMinValueOutsideLongRange() {
+        final BigIntegerValidator instance = BigIntegerValidator.getInstance();
+        final BigInteger aboveMax = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);
+        final BigInteger belowMin = BigInteger.valueOf(Long.MIN_VALUE).subtract(BigInteger.ONE);
+        // aboveMax is greater than every long, so it is >= any long minimum
+        assertTrue(instance.minValue(aboveMax, Long.MAX_VALUE));
+        assertTrue(instance.minValue(aboveMax, Long.MIN_VALUE));
+        // belowMin is smaller than every long, so it is not >= any long minimum
+        assertFalse(instance.minValue(belowMin, Long.MIN_VALUE));
+        assertFalse(instance.minValue(belowMin, Long.MAX_VALUE));
     }
 
     /**


### PR DESCRIPTION
minValue narrows the BigInteger to a long before comparing, so any value outside long range gives the wrong answer, whereas the sibling maxValue and isInRange already compare with compareTo.

1. value.longValue() keeps only the low 64 bits, so a value such as 2^63 is compared as 0 and a value just past Long.MIN_VALUE wraps to a large positive, which makes minValue disagree with this class's own maxValue/isInRange.
2. commit eafeda9 moved isInRange and maxValue onto compareTo(BigInteger.valueOf(...)) but left minValue on longValue(), so the gap stayed: minValue(2^64, 5) returns false although 2^64 is clearly greater than 5.

I switched minValue to the same compareTo form. Two assertions in testBigIntegerAboveLongMaxValue and testBigIntegerBelowLongMinValue were matching the truncated output (a value above Long.MAX_VALUE was treated as not greater-or-equal to Long.MAX_VALUE), so I corrected those to the right results and added a small test built from exact BigIntegers, which sidesteps the double rounding the parsed cases go through.