### PR TITLE
Reject non-ASCII hex digits in isValidInet6Address

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/InetAddressValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/InetAddressValidator.java
@@ -201,9 +201,14 @@ public class InetAddressValidator implements Serializable {
                 if (octet.length() > IPV6_MAX_HEX_DIGITS_PER_GROUP) {
                     return false;
                 }
-                final char char0 = octet.charAt(0);
-                if (char0 == '+' || char0 == '-') {
-                    return false; // Integer.parseInt accepts a leading sign, which is not a valid hex group
+                // Only ASCII hex digits are valid. Integer.parseInt(_, 16) also tolerates a leading sign
+                // and the non-ASCII Unicode digits that Character.digit maps to 0-15 (for example the
+                // fullwidth and Arabic-Indic forms), none of which belong in an IPv6 hex group.
+                for (int n = 0; n < octet.length(); n++) {
+                    final char ch = octet.charAt(n);
+                    if ((ch < '0' || ch > '9') && (ch < 'A' || ch > 'F') && (ch < 'a' || ch > 'f')) {
+                        return false;
+                    }
                 }
                 int octetInt = 0;
                 try {

--- a/src/test/java/org/apache/commons/validator/routines/InetAddressValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/InetAddressValidatorTest.java
@@ -162,6 +162,9 @@ class InetAddressValidatorTest {
         assertFalse(validator.isValidInet6Address("1:2:3:4:5:6:7:+8"), "IPV6 1:2:3:4:5:6:7:+8 should be invalid"); // signed hex group
         assertFalse(validator.isValidInet6Address("fe80::+1"), "IPV6 fe80::+1 should be invalid"); // signed hex group
         assertFalse(validator.isValidInet6Address("::+f"), "IPV6 ::+f should be invalid"); // signed hex group
+        assertFalse(validator.isValidInet6Address("１２３４::"), "IPV6 with fullwidth digits should be invalid"); // non-ASCII hex group
+        assertFalse(validator.isValidInet6Address("١٢::"), "IPV6 with Arabic-Indic digits should be invalid"); // non-ASCII hex group
+        assertFalse(validator.isValidInet6Address("1:2:3:4:5:6:7:８"), "IPV6 with a fullwidth digit group should be invalid"); // non-ASCII hex group
         assertTrue(validator.isValidInet6Address("1:2:3:4::7:8"), "IPV6 1:2:3:4::7:8 should be valid");
         assertTrue(validator.isValidInet6Address("1:2:3::7:8"), "IPV6 1:2:3::7:8 should be valid");
         assertTrue(validator.isValidInet6Address("1:2::7:8"), "IPV6 1:2::7:8 should be valid");


### PR DESCRIPTION
isValidInet6Address splits the address on ':' and hands each hex group straight to Integer.parseInt(octet, 16). That parser is more permissive than an IPv6 group should be: it delegates to Character.digit, which maps non-ASCII Unicode digits to 0-15, so a group written with fullwidth digits (U+FF10-FF19) or Arabic-Indic digits (U+0660-0669) parses cleanly and slips through the length and range checks. The result is that addresses such as the fullwidth "1234::" are reported as valid IPv6 addresses even though java.net.InetAddress and every real resolver reject them. The same gap is reachable through EmailValidator (bracketed IPv6 domain) and the UrlValidator authority, so a caller relying on this for a host allowlist can be fed a value that validates here but resolves elsewhere. The IPv4 path is unaffected because its regex \d only matches ASCII digits.

The existing guard already rejected a leading sign for the same reason (Integer.parseInt tolerating input that is not a real group). I have widened that single check into a per-character test that accepts only [0-9A-Fa-f], which covers the sign case and the non-ASCII digits in one place rather than enumerating each offending form. Keeping the check next to the parse means the rule stays where the value is actually consumed. Added regression tests alongside the existing signed-group cases.
