### PR TITLE
Preserve exact value in BigDecimal and BigInteger validate

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/BigDecimalValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/BigDecimalValidator.java
@@ -18,6 +18,7 @@
 package org.apache.commons.validator.routines;
 
 import java.math.BigDecimal;
+import java.text.DecimalFormat;
 import java.text.Format;
 import java.text.NumberFormat;
 import java.util.Locale;
@@ -218,6 +219,28 @@ public class BigDecimalValidator extends AbstractNumberValidator {
     @Override
     public boolean minValue(final Number value, final Number min) {
         return isFinite(value) && isFinite(min) ? compareTo(value, min) >= 0 : value.doubleValue() >= min.doubleValue();
+    }
+
+    /**
+     * Returns a {@code Format} that parses to a {@code BigDecimal} so the exact value of the input is preserved.
+     *
+     * <p>
+     * The superclass leaves {@link DecimalFormat} in its default mode, where {@code parse} yields a {@code Double} for a
+     * fractional value and so rounds an input carrying more significant digits than a {@code double} can hold. Enabling
+     * {@link DecimalFormat#setParseBigDecimal(boolean)} keeps the value as a {@code BigDecimal} through parsing.
+     * </p>
+     *
+     * @param pattern The pattern used to validate the value against or {@code null} to use the default for the {@link Locale}.
+     * @param locale  The locale to use for the format, system default if null.
+     * @return The {@code Format} to use.
+     */
+    @Override
+    protected Format getFormat(final String pattern, final Locale locale) {
+        final Format format = super.getFormat(pattern, locale);
+        if (format instanceof DecimalFormat) {
+            ((DecimalFormat) format).setParseBigDecimal(true);
+        }
+        return format;
     }
 
     /**

--- a/src/main/java/org/apache/commons/validator/routines/BigIntegerValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/BigIntegerValidator.java
@@ -19,6 +19,7 @@ package org.apache.commons.validator.routines;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.text.DecimalFormat;
 import java.text.Format;
 import java.text.NumberFormat;
 import java.util.Locale;
@@ -181,6 +182,29 @@ public class BigIntegerValidator extends AbstractNumberValidator {
     @Override
     public boolean minValue(final Number value, final Number min) {
         return toBigInteger(value).compareTo(toBigInteger(min)) >= 0;
+    }
+
+    /**
+     * Returns a {@code Format} that parses to a {@code BigDecimal} so the exact value of the input is preserved.
+     *
+     * <p>
+     * The superclass leaves {@link DecimalFormat} in its default mode, where {@code parse} yields a {@code Double} for a
+     * value outside the {@code long} range and so rounds an integer carrying more significant digits than a {@code double}
+     * can hold. Enabling {@link DecimalFormat#setParseBigDecimal(boolean)} keeps the full magnitude through parsing before
+     * it is converted to a {@code BigInteger}.
+     * </p>
+     *
+     * @param pattern The pattern used to validate the value against or {@code null} to use the default for the {@link Locale}.
+     * @param locale  The locale to use for the format, system default if null.
+     * @return The {@code Format} to use.
+     */
+    @Override
+    protected Format getFormat(final String pattern, final Locale locale) {
+        final Format format = super.getFormat(pattern, locale);
+        if (format instanceof DecimalFormat) {
+            ((DecimalFormat) format).setParseBigDecimal(true);
+        }
+        return format;
     }
 
     /**

--- a/src/test/java/org/apache/commons/validator/routines/BigDecimalValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/BigDecimalValidatorTest.java
@@ -54,7 +54,7 @@ class BigDecimalValidatorTest extends AbstractNumberValidatorTest {
         // testValid()
         testNumber = new BigDecimal("1234.5");
         final Number testNumber2 = new BigDecimal(".1");
-        final Number testNumber3 = new BigDecimal("12345.67899");
+        final Number testNumber3 = new BigDecimal("12345.678990");
         testZero = new BigDecimal("0");
         validStrict = new String[] { "0", "1234.5", "1,234.5", ".1", "12345.678990" };
         validStrictCompare = new Number[] { testZero, testNumber, testNumber, testNumber2, testNumber3 };
@@ -203,6 +203,21 @@ class BigDecimalValidatorTest extends AbstractNumberValidatorTest {
         assertTrue(validator.maxValue(number19, max), "maxValue(A) < max");
         assertTrue(validator.maxValue(number20, max), "maxValue(A) = max");
         assertFalse(validator.maxValue(number21, max), "maxValue(A) > max");
+    }
+
+    /**
+     * A value carrying more significant digits than a {@code double} can hold must be converted exactly. Parsing through a
+     * {@code double} rounds at about 17 digits, so the result has to come straight from the {@code BigDecimal} parse.
+     */
+    @Test
+    void testValueBeyondDoublePrecision() {
+        final BigDecimalValidator validator = BigDecimalValidator.getInstance();
+        final BigDecimal expected = new BigDecimal("0.12345678901234567890");
+        assertEquals(expected, validator.validate(expected.toPlainString(), Locale.US));
+
+        // 2^53 + 1 has 16 digits but is the smallest integer a double cannot represent
+        final BigDecimal unrepresentable = BigDecimal.valueOf(2).pow(53).add(BigDecimal.ONE);
+        assertEquals(unrepresentable, validator.validate(unrepresentable.toPlainString(), Locale.US));
     }
 
     /**

--- a/src/test/java/org/apache/commons/validator/routines/BigIntegerValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/BigIntegerValidatorTest.java
@@ -93,6 +93,21 @@ class BigIntegerValidatorTest extends AbstractNumberValidatorTest {
     }
 
     /**
+     * A value carrying more significant digits than a {@code double} can hold must be converted exactly. Scaling
+     * {@link Long#MAX_VALUE} up pushes past the roughly 17 significant digits a double can represent, so a result routed
+     * through a double would be rounded rather than preserved.
+     */
+    @Test
+    void testBigIntegerExactBeyondDoublePrecision() {
+        final BigInteger exact = BigInteger.valueOf(Long.MAX_VALUE).multiply(BigInteger.TEN).add(BigInteger.valueOf(7));
+        final String exactStr = exact.toString();
+        final BigIntegerValidator instance = BigIntegerValidator.getInstance();
+        assertEquals(exact, instance.validate(exactStr, "#"));
+        // BigInteger and BigDecimal validators must agree on the exact value
+        assertEquals(BigDecimalValidator.getInstance().validate(exactStr, "#").toBigInteger(), instance.validate(exactStr, "#"));
+    }
+
+    /**
      * Test a value larger than {@link Long#MAX_VALUE} keeps its magnitude instead of being clamped to {@link Long#MAX_VALUE}.
      */
     @Test


### PR DESCRIPTION
Following up on the earlier range-check work I checked what validate() actually hands back for high-precision input, and both validators drop digits. BigDecimalValidator.validate("0.12345678901234567890") returns 0.12345678901234568, and BigIntegerValidator on an integer past the long range (92233720368547758077) returns 92233720368547760000. The parse runs through the inherited NumberFormat, whose default DecimalFormat returns a Double for any fractional value or any integer outside long range, so the value is already rounded to roughly 17 significant figures before it is wrapped in a BigDecimal or BigInteger. For a pair of classes whose whole purpose is exact conversion that is a real correctness problem, and it is silent: no exception, just a different value than the caller supplied.

Overriding getFormat in each validator to put the DecimalFormat into setParseBigDecimal(true) makes parseObject return a BigDecimal up front, so the exact value reaches the conversion step. It belongs at the format layer because that is where the lossy Double is created, and nothing downstream can recover digits that parsing has already discarded. The two validators are kept in step, which an existing test already pins to the same magnitude, and one fixture that encoded the rounded result has been updated to the exact value. New regression tests cover a high-precision decimal and an integer scaled up from Long.MAX_VALUE.