### PR TITLE
Preserve fractional bound in BigIntegerValidator range checks

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/BigIntegerValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/BigIntegerValidator.java
@@ -89,6 +89,10 @@ public class BigIntegerValidator extends AbstractNumberValidator {
         if (value instanceof Long) {
             return BigDecimal.valueOf(value.longValue());
         }
+        if (value instanceof Double) {
+            // No need to roundtrip with a string.
+            return BigDecimal.valueOf(((Double) value).doubleValue());
+        }
         return new BigDecimal(value.toString());
     }
 

--- a/src/main/java/org/apache/commons/validator/routines/BigIntegerValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/BigIntegerValidator.java
@@ -79,6 +79,19 @@ public class BigIntegerValidator extends AbstractNumberValidator {
         return VALIDATOR;
     }
 
+    private static BigDecimal toBigDecimal(final Number value) {
+        if (value instanceof BigDecimal) {
+            return (BigDecimal) value;
+        }
+        if (value instanceof BigInteger) {
+            return new BigDecimal((BigInteger) value);
+        }
+        if (value instanceof Long) {
+            return BigDecimal.valueOf(value.longValue());
+        }
+        return new BigDecimal(value.toString());
+    }
+
     private static BigInteger toBigInteger(final Object value) {
         if (value instanceof Long) {
             return BigInteger.valueOf(((Long) value).longValue());
@@ -163,7 +176,8 @@ public class BigIntegerValidator extends AbstractNumberValidator {
      *
      * <p>
      * This overrides the {@link Number} overload inherited from the superclass, which narrows the value to a {@code long} before comparing and so loses
-     * magnitude for a {@code BigInteger} outside the long range.
+     * magnitude for a {@code BigInteger} outside the long range. The operands are compared as {@code BigDecimal} so a non-integer bound keeps its fractional
+     * part instead of being truncated towards zero.
      * </p>
      *
      * @param value The value validation is being performed on.
@@ -172,7 +186,7 @@ public class BigIntegerValidator extends AbstractNumberValidator {
      */
     @Override
     public boolean maxValue(final Number value, final Number max) {
-        return toBigInteger(value).compareTo(toBigInteger(max)) <= 0;
+        return toBigDecimal(value).compareTo(toBigDecimal(max)) <= 0;
     }
 
     /**
@@ -191,7 +205,8 @@ public class BigIntegerValidator extends AbstractNumberValidator {
      *
      * <p>
      * This overrides the {@link Number} overload inherited from the superclass, which narrows the value to a {@code long} before comparing and so loses
-     * magnitude for a {@code BigInteger} outside the long range.
+     * magnitude for a {@code BigInteger} outside the long range. The operands are compared as {@code BigDecimal} so a non-integer bound keeps its fractional
+     * part instead of being truncated towards zero.
      * </p>
      *
      * @param value The value validation is being performed on.
@@ -200,7 +215,7 @@ public class BigIntegerValidator extends AbstractNumberValidator {
      */
     @Override
     public boolean minValue(final Number value, final Number min) {
-        return toBigInteger(value).compareTo(toBigInteger(min)) >= 0;
+        return toBigDecimal(value).compareTo(toBigDecimal(min)) >= 0;
     }
 
     /**

--- a/src/test/java/org/apache/commons/validator/routines/BigIntegerValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/BigIntegerValidatorTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.util.Locale;
 
@@ -213,5 +214,28 @@ class BigIntegerValidatorTest extends AbstractNumberValidatorTest {
         final Number wrapsIntoRange = BigInteger.ONE.shiftLeft(Long.SIZE).add(BigInteger.valueOf(50));
         assertEquals(50L, wrapsIntoRange.longValue());
         assertFalse(instance.isInRange(wrapsIntoRange, min, max));
+    }
+
+    /**
+     * The {@link Number} overloads must compare against the exact bound. A non-integer bound was converted with BigInteger.toBigInteger(), which truncates
+     * towards zero, so a fractional minimum was floored (wrongly admitting a value below it) and a fractional maximum was floored too (wrongly admitting a value
+     * above a negative maximum).
+     */
+    @Test
+    void testNumberRangeFractionalBound() {
+        final AbstractNumberValidator instance = BigIntegerValidator.getInstance();
+        final Number five = BigInteger.valueOf(5);
+        // 5 >= 5.9 is false, but flooring the bound to 5 made it pass
+        assertFalse(instance.minValue(five, Double.valueOf(5.9)));
+        assertFalse(instance.minValue(five, new BigDecimal("5.9")));
+        // a whole-number bound is unaffected
+        assertTrue(instance.minValue(five, BigInteger.valueOf(5)));
+
+        final Number minusFive = BigInteger.valueOf(-5);
+        // -5 <= -5.9 is false, but flooring the bound to -5 made it pass
+        assertFalse(instance.maxValue(minusFive, Double.valueOf(-5.9)));
+        assertFalse(instance.maxValue(minusFive, new BigDecimal("-5.9")));
+        // -6 <= -5.9 is true
+        assertTrue(instance.maxValue(BigInteger.valueOf(-6), Double.valueOf(-5.9)));
     }
 }


### PR DESCRIPTION
The Number-typed minValue and maxValue overrides convert both operands with toBigInteger before comparing, and toBigInteger truncates a non-integer bound towards zero. A fractional bound therefore loses its fractional part before the test, so the verdict is wrong: minValue(BigInteger 5, 5.9) returns true although 5 is below 5.9 (the bound is floored to 5), and maxValue(BigInteger -5, -5.9) returns true although -5 is above -5.9. I noticed this while checking these overloads against BigDecimalValidator, which already compares the same mixed Number bounds exactly, so the two validators disagree on identical inputs.

The fix compares both operands as BigDecimal so a non-integer bound keeps its value. Whole-number bounds and BigIntegers outside the long range are unaffected, and keeping the comparison inside the override mirrors BigDecimalValidator rather than pushing rounding onto callers. Left unfixed, any range check given a Double, Float or BigDecimal bound with a fractional part can admit values just outside the requested range.