### PR TITLE
compare week-year not calendar year in compareWeeks

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/AbstractCalendarValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/AbstractCalendarValidator.java
@@ -39,11 +39,8 @@ public abstract class AbstractCalendarValidator extends AbstractFormatValidator 
 
     private static final long serialVersionUID = -1410008585975827379L;
 
-    /** Number of days in a week, beyond which two dates cannot share a week. */
-    private static final int DAYS_PER_WEEK = 7;
-
-    /** Number of milliseconds in a day, used to convert an instant to a day count. */
-    private static final long MILLIS_PER_DAY = TimeUnit.DAYS.toMillis(1);
+    /** Number of milliseconds in a week, beyond which two instants cannot share a week. */
+    private static final long MILLIS_PER_WEEK = TimeUnit.DAYS.toMillis(7);
 
     /**
      * The date style to use for Locale validation.
@@ -426,9 +423,9 @@ public abstract class AbstractCalendarValidator extends AbstractFormatValidator 
      * Compares the week two calendars fall in, ordering by the actual week rather than by the
      * {@code WEEK_OF_YEAR} or {@code WEEK_OF_MONTH} number alone. Those numbers repeat across the
      * boundaries they reset on (for example 31 December may be week 1 of the following year, and
-     * the first week of a month can hold days carried over from the previous month), so the day
-     * distance is checked first: dates a week or more apart are always in different weeks, and
-     * nearer dates share a week only when the week number also matches.
+     * the first week of a month can hold days carried over from the previous month), so the gap
+     * between the two instants is checked first: dates a week or more apart are always in different
+     * weeks, and nearer dates share a week only when the week number also matches.
      *
      * @param value The Calendar value.
      * @param compare The {@link Calendar} to check the value against.
@@ -436,23 +433,10 @@ public abstract class AbstractCalendarValidator extends AbstractFormatValidator 
      * @return Zero if both calendars are in the same week, -1 or +1 otherwise.
      */
     private int compareWeek(final Calendar value, final Calendar compare, final int field) {
-        final long days = epochDay(value) - epochDay(compare);
-        if (Math.abs(days) >= DAYS_PER_WEEK || calculateCompareResult(value, compare, field) != 0) {
-            return Long.signum(days);
+        final long millis = value.getTimeInMillis() - compare.getTimeInMillis();
+        if (Math.abs(millis) >= MILLIS_PER_WEEK || calculateCompareResult(value, compare, field) != 0) {
+            return Long.signum(millis);
         }
         return 0;
-    }
-
-    /**
-     * Returns the number of whole days from the epoch to the calendar's local date, so two
-     * calendars can be compared by date regardless of the time of day.
-     *
-     * @param calendar The calendar to convert.
-     * @return the day count from the epoch in the calendar's own time zone.
-     */
-    private static long epochDay(final Calendar calendar) {
-        final long localMillis = calendar.getTimeInMillis()
-                + calendar.get(Calendar.ZONE_OFFSET) + calendar.get(Calendar.DST_OFFSET);
-        return Math.floorDiv(localMillis, MILLIS_PER_DAY);
     }
 }

--- a/src/main/java/org/apache/commons/validator/routines/AbstractCalendarValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/AbstractCalendarValidator.java
@@ -23,6 +23,7 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Locale;
 import java.util.TimeZone;
+import java.util.concurrent.TimeUnit;
 
 import org.apache.commons.validator.GenericValidator;
 
@@ -37,6 +38,12 @@ import org.apache.commons.validator.GenericValidator;
 public abstract class AbstractCalendarValidator extends AbstractFormatValidator {
 
     private static final long serialVersionUID = -1410008585975827379L;
+
+    /** Number of days in a week, beyond which two dates cannot share a week. */
+    private static final int DAYS_PER_WEEK = 7;
+
+    /** Number of milliseconds in a day, used to convert an instant to a day count. */
+    private static final long MILLIS_PER_DAY = TimeUnit.DAYS.toMillis(1);
 
     /**
      * The date style to use for Locale validation.
@@ -117,15 +124,18 @@ public abstract class AbstractCalendarValidator extends AbstractFormatValidator 
 
         int result;
 
+        // Week of Year and Week of Month numbers repeat across the boundaries they reset on, and a
+        // week can belong to a different calendar year or month than its number suggests (for
+        // example 31 December may fall in week 1 of the following year), so the week is compared by
+        // day distance and week number rather than by comparing the calendar year first.
+        if (field == Calendar.WEEK_OF_YEAR || field == Calendar.WEEK_OF_MONTH) {
+            return compareWeek(value, compare, field);
+        }
+
         // Compare Year
         result = calculateCompareResult(value, compare, Calendar.YEAR);
         if (result != 0 || field == Calendar.YEAR) {
             return result;
-        }
-
-        // Compare Week of Year
-        if (field == Calendar.WEEK_OF_YEAR) {
-            return calculateCompareResult(value, compare, Calendar.WEEK_OF_YEAR);
         }
 
         // Compare Day of the Year
@@ -137,11 +147,6 @@ public abstract class AbstractCalendarValidator extends AbstractFormatValidator 
         result = calculateCompareResult(value, compare, Calendar.MONTH);
         if (result != 0 || field == Calendar.MONTH) {
             return result;
-        }
-
-        // Compare Week of Month
-        if (field == Calendar.WEEK_OF_MONTH) {
-            return calculateCompareResult(value, compare, Calendar.WEEK_OF_MONTH);
         }
 
         // Compare Date
@@ -416,4 +421,38 @@ public abstract class AbstractCalendarValidator extends AbstractFormatValidator 
      */
     @Override
     protected abstract Object processParsedValue(Object value, Format formatter);
+
+    /**
+     * Compares the week two calendars fall in, ordering by the actual week rather than by the
+     * {@code WEEK_OF_YEAR} or {@code WEEK_OF_MONTH} number alone. Those numbers repeat across the
+     * boundaries they reset on (for example 31 December may be week 1 of the following year, and
+     * the first week of a month can hold days carried over from the previous month), so the day
+     * distance is checked first: dates a week or more apart are always in different weeks, and
+     * nearer dates share a week only when the week number also matches.
+     *
+     * @param value The Calendar value.
+     * @param compare The {@link Calendar} to check the value against.
+     * @param field {@code Calendar.WEEK_OF_YEAR} or {@code Calendar.WEEK_OF_MONTH}.
+     * @return Zero if both calendars are in the same week, -1 or +1 otherwise.
+     */
+    private int compareWeek(final Calendar value, final Calendar compare, final int field) {
+        final long days = epochDay(value) - epochDay(compare);
+        if (Math.abs(days) >= DAYS_PER_WEEK || calculateCompareResult(value, compare, field) != 0) {
+            return Long.signum(days);
+        }
+        return 0;
+    }
+
+    /**
+     * Returns the number of whole days from the epoch to the calendar's local date, so two
+     * calendars can be compared by date regardless of the time of day.
+     *
+     * @param calendar The calendar to convert.
+     * @return the day count from the epoch in the calendar's own time zone.
+     */
+    private static long epochDay(final Calendar calendar) {
+        final long localMillis = calendar.getTimeInMillis()
+                + calendar.get(Calendar.ZONE_OFFSET) + calendar.get(Calendar.DST_OFFSET);
+        return Math.floorDiv(localMillis, MILLIS_PER_DAY);
+    }
 }

--- a/src/test/java/org/apache/commons/validator/routines/CalendarValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/CalendarValidatorTest.java
@@ -233,6 +233,52 @@ class CalendarValidatorTest extends AbstractCalendarValidatorTest {
     }
 
     /**
+     * Test compareWeeks() across the year boundary, where WEEK_OF_YEAR repeats: 31 December can be
+     * week 1 of the next year while 1 January of the same calendar year is also week 1.
+     */
+    @Test
+    @DefaultLocale(country = "US", language = "en")
+    void testCompareWeeksAcrossYearBoundary() {
+        final int noon = 120000;
+        // US locale: week starts Sunday, so Sun 30 Dec 2018 to Sat 5 Jan 2019 is a single week
+        final Calendar dec30y2018 = createCalendar(TimeZones.GMT, 20181230, noon);
+        final Calendar dec31y2018 = createCalendar(TimeZones.GMT, 20181231, noon);
+        final Calendar jan01y2018 = createCalendar(TimeZones.GMT, 20180101, noon);
+        final Calendar jan01y2019 = createCalendar(TimeZones.GMT, 20190101, noon);
+        final Calendar jan05y2019 = createCalendar(TimeZones.GMT, 20190105, noon);
+
+        // both are calendar year 2018 and WEEK_OF_YEAR 1, but lie ~52 weeks apart
+        assertEquals(1, calValidator.compareWeeks(dec31y2018, jan01y2018), "Dec 31 2018 is weeks after Jan 1 2018");
+        assertEquals(-1, calValidator.compareWeeks(jan01y2018, dec31y2018), "Jan 1 2018 is weeks before Dec 31 2018");
+
+        // different calendar years but the same week
+        assertEquals(0, calValidator.compareWeeks(dec31y2018, jan01y2019), "Dec 31 2018 is the same week as Jan 1 2019");
+
+        // the whole Sun 30 Dec 2018 to Sat 5 Jan 2019 span is one week
+        assertEquals(0, calValidator.compareWeeks(dec30y2018, jan05y2019), "Dec 30 2018 is the same week as Jan 5 2019");
+    }
+
+    /**
+     * Test WEEK_OF_MONTH comparison across a month/year boundary, where the week number resets and
+     * the first week of a month can hold days carried over from the previous month.
+     */
+    @Test
+    @DefaultLocale(country = "US", language = "en")
+    void testCompareWeekOfMonthAcrossBoundary() {
+        final int noon = 120000;
+        final Calendar dec30y2018 = createCalendar(TimeZones.GMT, 20181230, noon);
+        final Calendar dec31y2018 = createCalendar(TimeZones.GMT, 20181231, noon);
+        final Calendar jan01y2019 = createCalendar(TimeZones.GMT, 20190101, noon);
+
+        // 30 and 31 Dec 2018 fall in the same week of December
+        assertEquals(0, calValidator.compare(dec30y2018, dec31y2018, Calendar.WEEK_OF_MONTH), "Dec 30 and 31 2018 are the same week of month");
+
+        // 31 Dec 2018 and 1 Jan 2019 are one day apart but lie in different weeks of their months
+        assertEquals(-1, calValidator.compare(dec31y2018, jan01y2019, Calendar.WEEK_OF_MONTH), "Dec 31 2018 is before Jan 1 2019 by week of month");
+        assertEquals(1, calValidator.compare(jan01y2019, dec31y2018, Calendar.WEEK_OF_MONTH), "Jan 1 2019 is after Dec 31 2018 by week of month");
+    }
+
+    /**
      * Test Date/Time style Validator (there isn't an implementation for this)
      */
     @Test


### PR DESCRIPTION
compareWeeks reports 31 December and 1 January of the same calendar year as the same week. AbstractCalendarValidator.compare ordered the WEEK_OF_YEAR comparison on Calendar.YEAR and then the week number, but a week belongs to its own week-year, and at the turn of the year that week-year differs from the calendar year. Under the US locale 31 Dec 2018 has WEEK_OF_YEAR 1 and a week-year of 2019, so against 1 Jan 2018 (also WEEK_OF_YEAR 1) the year and the week number both match and two dates roughly 52 weeks apart compare equal. The mirror case fails the other way: 31 Dec 2018 and 1 Jan 2019 share one week yet compare as different weeks because their calendar years differ. WEEK_OF_MONTH resets the same way at the start of a month.

Following the review, this now orders both WEEK_OF_YEAR and WEEK_OF_MONTH by the distance in days first: dates a week or more apart are always in different weeks, and nearer dates share a week only when the week number also matches. That removes the year-boundary false match for WEEK_OF_YEAR and is correct by construction for WEEK_OF_MONTH, which keeps its previous results. It also drops the earlier getWeekYear() lookup and its unsupported-calendar fallback. Tests cover both fields across the year boundary and the full suite passes.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
