### PR TITLE
classify xn--90ae (бг) as a country-code TLD

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/DomainValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/DomainValidator.java
@@ -1370,7 +1370,6 @@ public class DomainValidator implements Serializable {
         "xn--80asehdb", // онлайн CORE Association
         "xn--80aswg", // сайт CORE Association
         "xn--8y0a063a", // 联通 China United Network Communications Corporation Limited
-        "xn--90ae", // бг Imena.BG Plc (NAMES.BG Plc)
         "xn--9dbq2a", // קום VeriSign Sarl
         "xn--9et52u", // 时尚 RISE VICTORY LIMITED
         "xn--9krt00a", // 微博 Sina Corporation
@@ -1725,6 +1724,7 @@ public class DomainValidator implements Serializable {
         "xn--54b7fta0cc", // বাংলা Posts and Telecommunications Division
         "xn--80ao21a", // қаз Association of IT Companies of Kazakhstan
         "xn--90a3ac", // срб Serbian National Internet Domain Registry (RNIDS)
+        "xn--90ae", // бг Imena.BG Plc (NAMES.BG Plc)
         "xn--90ais", // ??? Reliable Software Inc.
         "xn--clchc0ea0b2g2a9gcd", // சிங்கப்பூர் Singapore Network Information Centre (SGNIC) Pte Ltd
         "xn--d1alf", // мкд Macedonian Academic Research Network Skopje

--- a/src/test/java/org/apache/commons/validator/routines/DomainValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/DomainValidatorTest.java
@@ -584,6 +584,10 @@ public class DomainValidatorTest {
         assertTrue(validator.isValidCountryCodeTld(".uk"), ".uk should validate as ccTLD");
         assertFalse(validator.isValidCountryCodeTld(".org"), ".org shouldn't validate as ccTLD");
 
+        // бг (xn--90ae) is the IDN ccTLD for Bulgaria, not a gTLD
+        assertTrue(validator.isValidCountryCodeTld("xn--90ae"), "xn--90ae (бг) should validate as ccTLD");
+        assertFalse(validator.isValidGenericTld("xn--90ae"), "xn--90ae (бг) shouldn't validate as gTLD");
+
         // case-insensitive
         assertTrue(validator.isValidTld(".COM"), ".COM should validate as TLD");
         assertTrue(validator.isValidTld(".BiZ"), ".BiZ should validate as TLD");


### PR DESCRIPTION
DomainValidator keeps the IANA TLD lists as sorted arrays and decides a TLD's category from which array holds it. While going over the IDN country-code entries I noticed бг (punycode xn--90ae) sitting in GENERIC_TLDS, even though its Cyrillic neighbours срб and бел are in COUNTRY_CODE_TLDS. бг is the ccTLD delegated to Bulgaria for the two-letter code BG, so isValidCountryCodeTld("xn--90ae") and isValidCountryCodeTld("бг") wrongly return false while isValidGenericTld("xn--90ae") returns true.

Moving the entry into COUNTRY_CODE_TLDS, in its sorted position so the binary-search lookup still holds, makes the per-category checks agree with the IANA delegation. isValidTld and isValid already returned true through the category OR, so only the category-specific methods change behaviour. Left as is, callers that branch on TLD category (treating ccTLDs differently from gTLDs) mishandle Bulgarian domains. Added the matching assertions to DomainValidatorTest.testTopLevelDomains.
