### PR TITLE
Compare exact values in DoubleValidator range checks

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/DoubleValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/DoubleValidator.java
@@ -184,6 +184,42 @@ public class DoubleValidator extends AbstractNumberValidator {
     }
 
     /**
+     * Tests if the value is less than or equal to a maximum, comparing the exact values.
+     *
+     * <p>
+     * This overrides the {@link Number} overload inherited from the superclass, which narrows the bound to a {@code double} before comparing and so loses
+     * precision for a {@code BigDecimal} or {@code BigInteger} bound that carries more significant digits than a {@code double} can hold. A non-finite
+     * {@link Double} or {@link Float} operand keeps the {@code doubleValue()} comparison so the documented infinity behaviour is unchanged.
+     * </p>
+     *
+     * @param value The value validation is being performed on.
+     * @param max   The maximum value.
+     * @return {@code true} if the value is less than or equal to the maximum.
+     */
+    @Override
+    public boolean maxValue(final Number value, final Number max) {
+        return isFinite(value) && isFinite(max) ? compareTo(value, max) <= 0 : value.doubleValue() <= max.doubleValue();
+    }
+
+    /**
+     * Tests if the value is greater than or equal to a minimum, comparing the exact values.
+     *
+     * <p>
+     * This overrides the {@link Number} overload inherited from the superclass, which narrows the bound to a {@code double} before comparing and so loses
+     * precision for a {@code BigDecimal} or {@code BigInteger} bound that carries more significant digits than a {@code double} can hold. A non-finite
+     * {@link Double} or {@link Float} operand keeps the {@code doubleValue()} comparison so the documented infinity behaviour is unchanged.
+     * </p>
+     *
+     * @param value The value validation is being performed on.
+     * @param min   The minimum value.
+     * @return {@code true} if the value is greater than or equal to the minimum.
+     */
+    @Override
+    public boolean minValue(final Number value, final Number min) {
+        return isFinite(value) && isFinite(min) ? compareTo(value, min) >= 0 : value.doubleValue() >= min.doubleValue();
+    }
+
+    /**
      * Convert the parsed value to a {@code Double}.
      *
      * @param value The parsed {@code Number} object created.

--- a/src/test/java/org/apache/commons/validator/routines/DoubleValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/DoubleValidatorTest.java
@@ -136,8 +136,8 @@ class DoubleValidatorTest extends AbstractNumberValidatorTest {
 
     /**
      * Test the {@link Number} range checks against a bound that carries more precision than a {@code double}.
-     * 2^53 is the largest integer with an exact {@code double} representation, so 2^53 + 1 cannot be narrowed
-     * onto the value: a value of 2^53 is below a minimum of 2^53 + 1 and above a maximum of 2^53 - 0.5.
+     * {@code 2^53} is the largest integer with an exact {@code double} representation, so {@code 2^53} + 1 cannot be narrowed
+     * onto the value: a value of {@code 2^53} is below a minimum of {@code 2^53 + 1} and above a maximum of {@code 2^53 - 0.5}.
      */
     @Test
     void testDoubleNumberRangeExactBound() {

--- a/src/test/java/org/apache/commons/validator/routines/DoubleValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/DoubleValidatorTest.java
@@ -22,6 +22,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.text.DecimalFormatSymbols;
 import java.util.Locale;
 
@@ -130,6 +132,26 @@ class DoubleValidatorTest extends AbstractNumberValidatorTest {
         assertFalse(validator.minValue(Double.NaN, 10), "minValue() NaN");
         // maxValue() with NaN: NaN <= max is always false
         assertFalse(validator.maxValue(Double.NaN, 20), "maxValue() NaN");
+    }
+
+    /**
+     * Test the {@link Number} range checks against a bound that carries more precision than a {@code double}.
+     * 2^53 is the largest integer with an exact {@code double} representation, so 2^53 + 1 cannot be narrowed
+     * onto the value: a value of 2^53 is below a minimum of 2^53 + 1 and above a maximum of 2^53 - 0.5.
+     */
+    @Test
+    void testDoubleNumberRangeExactBound() {
+        final DoubleValidator validator = (DoubleValidator) strictValidator;
+        final long maxExactInt = 1L << 53; // 2^53
+        final Double value = Double.valueOf(maxExactInt);
+        final BigInteger above = BigInteger.valueOf(maxExactInt).add(BigInteger.ONE); // 2^53 + 1
+        final BigInteger below = BigInteger.valueOf(maxExactInt).subtract(BigInteger.ONE); // 2^53 - 1
+        final BigDecimal justBelow = BigDecimal.valueOf(maxExactInt).subtract(BigDecimal.valueOf(0.5)); // 2^53 - 0.5
+        assertFalse(validator.minValue(value, above), "minValue() bound above value");
+        assertTrue(validator.minValue(value, below), "minValue() bound below value");
+        assertFalse(validator.maxValue(value, justBelow), "maxValue() bound below value");
+        assertTrue(validator.maxValue(value, above), "maxValue() bound above value");
+        assertFalse(validator.isInRange(value, above, above.add(BigInteger.ONE)), "isInRange() value below range");
     }
 
     /**


### PR DESCRIPTION
The `Number`-typed range overloads on `DoubleValidator` are inherited from `AbstractNumberValidator`, which tests `value.doubleValue()` against `bound.doubleValue()`. That narrows the bound to a `double` before comparing, so a `BigDecimal` or `BigInteger` bound carrying more significant digits than a `double` can hold is rounded onto the value first. `minValue(2^53, BigInteger 2^53 + 1)` returns `true` and `maxValue(2^53, 2^53 - 0.5)` returns `true`, both wrong: a value that sits outside the bound is reported as in range, and it then slips through any `isInRange` guard built on these methods.

The two overrides defer to the superclass `compareTo(Number, Number)`, so the bound's precision survives; this mirrors the `compareTo` comparisons already used in `BigIntegerValidator` and `BigDecimalValidator`. A non-finite operand keeps the old `doubleValue()` comparison so the documented infinity and NaN behaviour is unchanged. Placing the check in the callee means `isInRange(Number, Number, Number)` picks it up through virtual dispatch rather than each caller needing its own guard.

This was originally paired with the same change to `FloatValidator`, but I've dropped that half: at the magnitude where the bound-narrowing bug bites (around 2^53) a `float` spans roughly 10^9 per step, so the bound that triggers the bug always lands inside the value's round-trip interval, where `Float.toString` (which drives `compareTo`) differs between JDKs. That made the float regression test pass on JDK 21 but fail on JDK 8, and there's no portable way to pin it. `DoubleValidator` has no such window, so I've scoped this PR to it.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
