### PR TITLE
trim input in IBANValidator.validate

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/IBANValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/IBANValidator.java
@@ -417,16 +417,17 @@ public class IBANValidator {
      * @since 1.10.0
      */
     public IBANValidatorStatus validate(final String code) {
-        final Validator formatValidator = getValidator(code);
+        final String iban = code == null ? null : code.trim();
+        final Validator formatValidator = getValidator(iban);
         if (formatValidator == null) {
             return IBANValidatorStatus.UNKNOWN_COUNTRY;
         }
-        if (code.length() != formatValidator.ibanLength) {
+        if (iban.length() != formatValidator.ibanLength) {
             return IBANValidatorStatus.INVALID_LENGTH;
         }
-        if (!formatValidator.regexValidator.isValid(code)) {
+        if (!formatValidator.regexValidator.isValid(iban)) {
             return IBANValidatorStatus.INVALID_PATTERN;
         }
-        return IBANCheckDigit.IBAN_CHECK_DIGIT.isValid(code) ? IBANValidatorStatus.VALID : IBANValidatorStatus.INVALID_CHECKSUM;
+        return IBANCheckDigit.IBAN_CHECK_DIGIT.isValid(iban) ? IBANValidatorStatus.VALID : IBANValidatorStatus.INVALID_CHECKSUM;
     }
 }

--- a/src/test/java/org/apache/commons/validator/routines/IBANValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/IBANValidatorTest.java
@@ -391,7 +391,10 @@ class IBANValidatorTest {
                 Arguments.of("AD0101", IBANValidatorStatus.INVALID_LENGTH),
                 Arguments.of("AD12XX012030200359100100", IBANValidatorStatus.INVALID_PATTERN),
                 Arguments.of("AD9900012030200359100100", IBANValidatorStatus.INVALID_CHECKSUM),
-                Arguments.of("AD1200012030200359100100", IBANValidatorStatus.VALID)
+                Arguments.of("AD1200012030200359100100", IBANValidatorStatus.VALID),
+                Arguments.of(" AD1200012030200359100100", IBANValidatorStatus.VALID),
+                Arguments.of("AD1200012030200359100100 ", IBANValidatorStatus.VALID),
+                Arguments.of("  AD1200012030200359100100\n", IBANValidatorStatus.VALID)
         );
     }
 
@@ -537,6 +540,14 @@ class IBANValidatorTest {
     @MethodSource("validateIbanStatuses")
     void testValidateIbanStatuses(final String iban, final IBANValidatorStatus expectedStatus) {
         assertEquals(expectedStatus, IBANValidator.getInstance().validate(iban));
+    }
+
+    @Test
+    void testValidateSurroundingWhitespace() {
+        final String iban = "DE89370400440532013000";
+        assertEquals(IBANValidatorStatus.VALID, VALIDATOR.validate(" " + iban), "leading space");
+        assertEquals(IBANValidatorStatus.VALID, VALIDATOR.validate(iban + " "), "trailing space");
+        assertTrue(VALIDATOR.isValid("\t" + iban + "\n"), "isValid trims surrounding whitespace");
     }
 
     @ParameterizedTest


### PR DESCRIPTION
Noticed while validating IBANs read line by line out of a file: a value with a trailing newline came back INVALID_LENGTH and one with a leading space UNKNOWN_COUNTRY, although both validate once the surrounding whitespace is stripped.

1. validate(String) is the only validation method here and isValid delegates to it, yet it never normalises its argument, unlike CodeValidator.validate and the AbstractNumberValidator/AbstractCalendarValidator parse paths which all trim first.
2. the raw string is handed to getValidator, which reads the first two characters as the country code, so a leading space selects the wrong code and any surrounding whitespace also trips the fixed-length check, leaving the returned IBANValidatorStatus misleading rather than VALID.

Trimmed once at the top of validate and ran the country lookup, length, pattern and check digit against that value; the null path is unchanged as getValidator already tolerates null.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
