### PR TITLE
range-check the port for IPv6 hosts in isValidAuthority

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/UrlValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/UrlValidator.java
@@ -443,16 +443,19 @@ public class UrlValidator implements Serializable {
                     return false;
                 }
             }
-            final String port = authorityMatcher.group(PARSE_AUTHORITY_PORT);
-            if (!GenericValidator.isBlankOrNull(port)) {
-                try {
-                    final int iPort = Integer.parseInt(port);
-                    if (iPort < 0 || iPort > MAX_UNSIGNED_16_BIT_INT) {
-                        return false;
-                    }
-                } catch (final NumberFormatException nfe) {
-                    return false; // this can happen for big numbers
+        }
+
+        // the port is captured in the same group regardless of host form, so it must be
+        // range checked for a bracketed IPv6 host too, not just the hostname/IPv4 branch
+        final String port = authorityMatcher.group(PARSE_AUTHORITY_PORT);
+        if (!GenericValidator.isBlankOrNull(port)) {
+            try {
+                final int iPort = Integer.parseInt(port);
+                if (iPort < 0 || iPort > MAX_UNSIGNED_16_BIT_INT) {
+                    return false;
                 }
+            } catch (final NumberFormatException nfe) {
+                return false; // this can happen for big numbers
             }
         }
 

--- a/src/test/java/org/apache/commons/validator/routines/UrlValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/UrlValidatorTest.java
@@ -173,6 +173,17 @@ public class UrlValidatorTest {
         assertFalse(urlValidator.isValid("http://[::ffff:129.144.52.999]/"));
     }
 
+    @Test
+    void testIpv6Port() {
+        final UrlValidator urlValidator = new UrlValidator();
+        // a port on a bracketed IPv6 host must be range checked just like a hostname/IPv4 host
+        assertTrue(urlValidator.isValid("http://[::1]:65535/index.html"));
+        assertFalse(urlValidator.isValid("http://[::1]:65536/index.html"));
+        assertFalse(urlValidator.isValid("http://[::1]:99999/index.html"));
+        assertTrue(urlValidator.isValidAuthority("[::1]:65535"));
+        assertFalse(urlValidator.isValidAuthority("[::1]:65536"));
+    }
+
     @ParameterizedTest
     // @formatter:off
     @ValueSource(strings = {


### PR DESCRIPTION
**IPv6 host port skips the range check in isValidAuthority**

The port group in `AUTHORITY_PATTERN` is captured the same way for a bracketed IPv6 host as for a hostname or IPv4 host, but the 0 to 65535 range check only ran in the hostname/IPv4 branch of `isValidAuthority`. That left a gap: `http://[::1]:99999/` and `http://[::1]:65536/` validated as good while the equivalent `http://127.0.0.1:99999/` and `http://example.com:99999/` were correctly rejected, so an out-of-range port slipped through purely on the strength of the host being IPv6.

Moved the existing port parse and range check out of that branch so both host forms are checked the same way. Valid ports such as `[::1]:65535` and `[::1]:80`, and the no-port case, are unaffected. Added a regression test that fails without the change.