### PR TITLE
Fix swapped constant maps in Form.process for extended forms

### DIFF
--- a/src/main/java/org/apache/commons/validator/Form.java
+++ b/src/main/java/org/apache/commons/validator/Form.java
@@ -221,7 +221,7 @@ public class Form implements Serializable {
             if (parent != null) {
                 if (!parent.isProcessed()) {
                     // we want to go all the way up the tree
-                    parent.process(constants, globalConstants, forms);
+                    parent.process(globalConstants, constants, forms);
                 }
                 for (final Field f : parent.getFields()) {
                     // we want to be able to override any fields we like

--- a/src/test/java/org/apache/commons/validator/ExtensionTest.java
+++ b/src/test/java/org/apache/commons/validator/ExtensionTest.java
@@ -23,7 +23,9 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.InputStream;
+import java.util.HashMap;
 import java.util.Locale;
+import java.util.Map;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -106,6 +108,43 @@ class ExtensionTest {
         assertEquals("firstName", fieldFirstName.getKey(), "firstName in " + FORM_KEY2 + " should be the first in the list");
         assertEquals("lastName", fieldLastName.getKey(), "lastName in " + FORM_KEY2 + " should be the first in the list");
 
+    }
+
+    /**
+     * A form-set constant overrides a global constant of the same name, because {@link Field#process} applies the
+     * form-set constants before the global ones. This precedence must also hold for a form reached through extension:
+     * when {@link Form#process} recurses into the parent form it has to pass the global and form-set constants in the
+     * same order as for a non-extended form. With the arguments swapped the parent's fields resolve a shared constant
+     * to the global value instead of the form-set value.
+     */
+    @Test
+    void testConstantOrderWhenExtending() {
+        final Map<String, String> globalConstants = new HashMap<>();
+        globalConstants.put("greeting", "global");
+        final Map<String, String> constants = new HashMap<>();
+        constants.put("greeting", "formset");
+
+        final Field baseField = new Field();
+        baseField.setProperty("name");
+        baseField.addVar("msg", "${greeting}", null);
+
+        final Form baseForm = new Form();
+        baseForm.setName("baseForm");
+        baseForm.addField(baseField);
+
+        final Form childForm = new Form();
+        childForm.setName("childForm");
+        childForm.setExtends("baseForm");
+
+        final Map<String, Form> forms = new HashMap<>();
+        forms.put("baseForm", baseForm);
+        forms.put("childForm", childForm);
+
+        // Processing the child reaches the still-unprocessed parent through the extension branch of Form.process.
+        childForm.process(globalConstants, constants, forms);
+
+        assertEquals("formset", baseForm.getField("name").getVar("msg").getValue(),
+                "the form-set constant should override the global constant for an extended form");
     }
 
     /**


### PR DESCRIPTION
I was reading through the form-extension path and noticed `Form.process` calls itself with the first two arguments in a different order to the method's own signature and to the other two call sites, which is what put me onto this.

1. `Form.process` recurses into the inherited form at Form.java:224 as `parent.process(constants, globalConstants, forms)`, so the global map and the form-set map are swapped relative to the declared `process(globalConstants, constants, forms)`.
2. `Field.process` applies the form-set constants first and the global constants second, so for a shared constant name the form-set value is meant to win; because of the swap a parent form reached through `extends` resolves that constant to the global value instead, the opposite precedence to a non-extended form and to the correct calls at Form.java:240 and FormSet.java:312.
3. Restored the declared argument order on the recursive call, and added a regression test in `ExtensionTest` that extends a base form sharing a constant name with a global one and asserts the form-set value wins; it fails before this change (`expected: <formset> but was: <global>`) and passes after.

Left unfixed, any form that uses `extends` together with a form-set constant overriding a like-named global constant silently picks up the wrong value, and which value wins also depends on the form iteration order, so it is not deterministic across runs.

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
