### PR TITLE
Handle non-finite bounds in BigIntegerValidator range checks

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/BigIntegerValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/BigIntegerValidator.java
@@ -152,7 +152,8 @@ public class BigIntegerValidator extends AbstractNumberValidator {
      * <p>
      * This overrides the {@link Number} overload inherited from the superclass, which narrows the value to a {@code long} before comparing and so loses
      * magnitude for a {@code BigInteger} outside the long range. The operands are compared as {@code BigDecimal} so a non-integer bound keeps its fractional
-     * part instead of being truncated towards zero.
+     * part instead of being truncated towards zero. A non-finite {@link Double} or {@link Float} operand keeps the {@code doubleValue()} comparison, since
+     * {@code BigDecimal} cannot represent {@code NaN} or an infinity.
      * </p>
      *
      * @param value The value validation is being performed on.
@@ -161,7 +162,7 @@ public class BigIntegerValidator extends AbstractNumberValidator {
      */
     @Override
     public boolean maxValue(final Number value, final Number max) {
-        return toBigDecimal(value).compareTo(toBigDecimal(max)) <= 0;
+        return isFinite(value) && isFinite(max) ? compareTo(value, max) <= 0 : value.doubleValue() <= max.doubleValue();
     }
 
     /**
@@ -181,7 +182,8 @@ public class BigIntegerValidator extends AbstractNumberValidator {
      * <p>
      * This overrides the {@link Number} overload inherited from the superclass, which narrows the value to a {@code long} before comparing and so loses
      * magnitude for a {@code BigInteger} outside the long range. The operands are compared as {@code BigDecimal} so a non-integer bound keeps its fractional
-     * part instead of being truncated towards zero.
+     * part instead of being truncated towards zero. A non-finite {@link Double} or {@link Float} operand keeps the {@code doubleValue()} comparison, since
+     * {@code BigDecimal} cannot represent {@code NaN} or an infinity.
      * </p>
      *
      * @param value The value validation is being performed on.
@@ -190,7 +192,7 @@ public class BigIntegerValidator extends AbstractNumberValidator {
      */
     @Override
     public boolean minValue(final Number value, final Number min) {
-        return toBigDecimal(value).compareTo(toBigDecimal(min)) >= 0;
+        return isFinite(value) && isFinite(min) ? compareTo(value, min) >= 0 : value.doubleValue() >= min.doubleValue();
     }
 
     /**

--- a/src/test/java/org/apache/commons/validator/routines/BigIntegerValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/BigIntegerValidatorTest.java
@@ -238,4 +238,30 @@ class BigIntegerValidatorTest extends AbstractNumberValidatorTest {
         assertEquals(50L, wrapsIntoRange.longValue());
         assertFalse(instance.isInRange(wrapsIntoRange, min, max));
     }
+
+    /**
+     * A non-finite {@link Double} bound must not be routed through {@link BigDecimal}, which cannot represent {@code NaN} or an infinity. The {@link Number}
+     * overloads previously converted every bound to a {@code BigDecimal} and so threw {@code NumberFormatException} for such a bound, whereas the sibling
+     * {@link BigDecimalValidator} already handled it. The behaviour now matches: a {@code NaN} bound is never satisfied, and an infinity is an open bound.
+     */
+    @Test
+    void testNumberRangeNonFiniteBound() {
+        final AbstractNumberValidator instance = BigIntegerValidator.getInstance();
+        final Number value = BigInteger.valueOf(100);
+
+        // NaN bound: nothing compares against NaN
+        assertFalse(instance.maxValue(value, Double.NaN));
+        assertFalse(instance.minValue(value, Double.NaN));
+        assertFalse(instance.isInRange(value, 0, Double.NaN));
+        assertFalse(instance.isInRange(value, Double.NaN, 200));
+
+        // POSITIVE_INFINITY as a maximum / NEGATIVE_INFINITY as a minimum are open bounds any finite value meets
+        assertTrue(instance.maxValue(value, Double.POSITIVE_INFINITY));
+        assertTrue(instance.minValue(value, Double.NEGATIVE_INFINITY));
+        assertTrue(instance.isInRange(value, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY));
+
+        // POSITIVE_INFINITY as a minimum / NEGATIVE_INFINITY as a maximum cannot be met
+        assertFalse(instance.minValue(value, Double.POSITIVE_INFINITY));
+        assertFalse(instance.maxValue(value, Double.NEGATIVE_INFINITY));
+    }
 }

--- a/src/test/java/org/apache/commons/validator/routines/BigIntegerValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/BigIntegerValidatorTest.java
@@ -248,18 +248,15 @@ class BigIntegerValidatorTest extends AbstractNumberValidatorTest {
     void testNumberRangeNonFiniteBound() {
         final AbstractNumberValidator instance = BigIntegerValidator.getInstance();
         final Number value = BigInteger.valueOf(100);
-
         // NaN bound: nothing compares against NaN
         assertFalse(instance.maxValue(value, Double.NaN));
         assertFalse(instance.minValue(value, Double.NaN));
         assertFalse(instance.isInRange(value, 0, Double.NaN));
         assertFalse(instance.isInRange(value, Double.NaN, 200));
-
         // POSITIVE_INFINITY as a maximum / NEGATIVE_INFINITY as a minimum are open bounds any finite value meets
         assertTrue(instance.maxValue(value, Double.POSITIVE_INFINITY));
         assertTrue(instance.minValue(value, Double.NEGATIVE_INFINITY));
         assertTrue(instance.isInRange(value, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY));
-
         // POSITIVE_INFINITY as a minimum / NEGATIVE_INFINITY as a maximum cannot be met
         assertFalse(instance.minValue(value, Double.POSITIVE_INFINITY));
         assertFalse(instance.maxValue(value, Double.NEGATIVE_INFINITY));

--- a/src/test/java/org/apache/commons/validator/routines/BigIntegerValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/BigIntegerValidatorTest.java
@@ -260,5 +260,22 @@ class BigIntegerValidatorTest extends AbstractNumberValidatorTest {
         // POSITIVE_INFINITY as a minimum / NEGATIVE_INFINITY as a maximum cannot be met
         assertFalse(instance.minValue(value, Double.POSITIVE_INFINITY));
         assertFalse(instance.maxValue(value, Double.NEGATIVE_INFINITY));
+        final Number posInf = Double.valueOf(Double.POSITIVE_INFINITY);
+        final Number negInf = Double.valueOf(Double.NEGATIVE_INFINITY);
+        final Number nan = Double.valueOf(Double.NaN);
+        // A non-finite value against itself: an infinity equals itself, NaN never compares equal
+        assertTrue(instance.maxValue(posInf, posInf));
+        assertTrue(instance.minValue(posInf, posInf));
+        assertTrue(instance.maxValue(negInf, negInf));
+        assertTrue(instance.minValue(negInf, negInf));
+        assertFalse(instance.maxValue(nan, nan));
+        assertFalse(instance.minValue(nan, nan));
+        // A non-finite value against a different non-finite bound: -inf < +inf, anything with NaN fails
+        assertTrue(instance.maxValue(negInf, posInf));
+        assertTrue(instance.minValue(posInf, negInf));
+        assertFalse(instance.maxValue(posInf, negInf));
+        assertFalse(instance.minValue(negInf, posInf));
+        assertFalse(instance.maxValue(posInf, nan));
+        assertFalse(instance.minValue(posInf, nan));
     }
 }


### PR DESCRIPTION
BigIntegerValidator's minValue(Number, Number) and maxValue(Number, Number) compare the operands as BigDecimal, but unlike the equivalent BigDecimalValidator overloads they never guard for a non-finite bound. A Double.NaN, POSITIVE_INFINITY or NEGATIVE_INFINITY argument is routed straight into BigDecimal.valueOf(double), which cannot represent those values and throws NumberFormatException, so the call (and the inherited isInRange that delegates to it) blows up with an undeclared exception rather than returning a boolean. I traced this from an open-ended range check where an infinite upper bound threw instead of accepting every finite value; BigDecimalValidator accepts the same bound without complaint, so the two validators disagree.

The fix guards both overrides with isFinite and falls back to the doubleValue() comparison when either operand is non-finite, mirroring BigDecimalValidator. The finite path is untouched, so the exact-magnitude and fractional-bound behaviour stays as it was; only the previously-throwing case changes, with a NaN bound never satisfied and an infinity treated as an open bound. Keeping the guard in the callee means every entry point stays consistent without callers having to sanitise their bounds first.