### PR TITLE
Reject vowels in SedolCheckDigit

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/SedolCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/SedolCheckDigit.java
@@ -89,7 +89,15 @@ public final class SedolCheckDigit extends ModulusCheckDigit {
         if (charValue > charValueMax || !isAsciiAlphaNum(character)) {
             throw new CheckDigitException("Invalid Character[%d,%d] = '%d' out of range 0 to %d", leftPos, rightPos, charValue, charValueMax);
         }
+        // The SEDOL alphabet omits the vowels A, E, I, O and U, so a code containing one is not a SEDOL.
+        if (isVowel(character)) {
+            throw new CheckDigitException("Invalid Character[%d,%d] = '%c' - vowels are not used in a SEDOL", leftPos, rightPos, character);
+        }
         return charValue;
+    }
+
+    private boolean isVowel(final char character) {
+        return "AEIOU".indexOf(Character.toUpperCase(character)) >= 0;
     }
 
     /**

--- a/src/test/java/org/apache/commons/validator/routines/checkdigit/SedolCheckDigitTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/checkdigit/SedolCheckDigitTest.java
@@ -51,4 +51,16 @@ class SedolCheckDigitTest extends AbstractCheckDigitTest {
         }
     }
 
+    /**
+     * SEDOLs never contain a vowel; each of these carries a correct modulus 10 check digit but a vowel in the
+     * six-character body, so the check digit alone would otherwise accept it.
+     */
+    @Test
+    void testVowelsRejected() {
+        final String[] withVowel = { "B0AKT02", "0EIOU02", "BAEIOU7", "AAAAAA0", };
+        for (final String code : withVowel) {
+            assertFalse(routine.isValid(code), "Should fail (contains a vowel): " + code);
+        }
+    }
+
 }

--- a/src/test/java/org/apache/commons/validator/routines/checkdigit/SedolCheckDigitTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/checkdigit/SedolCheckDigitTest.java
@@ -20,6 +20,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * ISIN Check Digit Test.
@@ -52,15 +54,14 @@ class SedolCheckDigitTest extends AbstractCheckDigitTest {
     }
 
     /**
-     * SEDOLs never contain a vowel; each of these carries a correct modulus 10 check digit but a vowel in the
-     * six-character body, so the check digit alone would otherwise accept it.
+     * SEDOLs never contain a vowel, yet each of these codes carries a correct modulus 10 check digit with a vowel in
+     * its body, so without the vowel exclusion the check digit alone would accept it. The first five isolate A, E, I,
+     * O and U individually; the remainder combine several.
      */
-    @Test
-    void testVowelsRejected() {
-        final String[] withVowel = { "B0AKT02", "0EIOU02", "BAEIOU7", "AAAAAA0", };
-        for (final String code : withVowel) {
-            assertFalse(routine.isValid(code), "Should fail (contains a vowel): " + code);
-        }
+    @ParameterizedTest
+    @ValueSource(strings = { "A000000", "E000006", "I000002", "O000006", "U000000", "B0AKT02", "0EIOU02", "BAEIOU7", "AAAAAA0" })
+    void testVowelsRejected(final String code) {
+        assertFalse(routine.isValid(code), "Should fail (contains a vowel): " + code);
     }
 
 }


### PR DESCRIPTION
`SedolCheckDigit.toInt` already rejects out-of-range and non-alphanumeric characters, but it accepts vowels. The SEDOL alphabet deliberately omits A, E, I, O and U (as noted in the Wikipedia reference in the class Javadoc), so no genuine SEDOL contains one. Whilst working through these routines I generated a correct modulus-10 check digit for bodies containing vowels and found `SEDOL_CHECK_DIGIT.isValid` returning true for codes such as `B0AKT02` and `AAAAAA0`. There is no `SedolValidator` wrapping this routine, so `SedolCheckDigit.isValid` is the only public SEDOL entry point and the over-acceptance is user visible: a string that can never be a real SEDOL passes validation purely because its check digit happens to line up.

The fix rejects vowels in `toInt`, next to the existing alphanumeric-range check, which is where the other per-character SEDOL rules already live, so the whole character set stays enforced in one place rather than being pushed onto callers. The added test asserts vowel-bearing codes with valid check digits are rejected while the existing consonant fixtures still validate; it fails before the change and passes after.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Run a successful build using the default Maven goal with `mvn`.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
