### PR TITLE
Compare exact bound in AbstractNumberValidator range checks

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/AbstractNumberValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/AbstractNumberValidator.java
@@ -272,6 +272,12 @@ public abstract class AbstractNumberValidator extends AbstractFormatValidator {
     /**
      * Tests if the value is less than or equal to a maximum.
      *
+     * <p>
+     * For an integer validator the bound is compared exactly rather than narrowed to a {@code long}, so a {@code BigInteger} or {@code BigDecimal} bound outside
+     * the long range keeps its magnitude and a fractional bound keeps its fractional part. A non-finite {@link Double} or {@link Float} operand keeps the
+     * {@code doubleValue()} comparison, since {@code BigDecimal} cannot represent {@code NaN} or an infinity.
+     * </p>
+     *
      * @param value The value validation is being performed on.
      * @param max   The maximum value.
      * @return {@code true} if the value is less than or equal to the maximum.
@@ -280,11 +286,17 @@ public abstract class AbstractNumberValidator extends AbstractFormatValidator {
         if (isAllowFractions()) {
             return value.doubleValue() <= max.doubleValue();
         }
-        return value.longValue() <= max.longValue();
+        return isFinite(value) && isFinite(max) ? compareTo(value, max) <= 0 : value.doubleValue() <= max.doubleValue();
     }
 
     /**
      * Tests if the value is greater than or equal to a minimum.
+     *
+     * <p>
+     * For an integer validator the bound is compared exactly rather than narrowed to a {@code long}, so a {@code BigInteger} or {@code BigDecimal} bound outside
+     * the long range keeps its magnitude and a fractional bound keeps its fractional part. A non-finite {@link Double} or {@link Float} operand keeps the
+     * {@code doubleValue()} comparison, since {@code BigDecimal} cannot represent {@code NaN} or an infinity.
+     * </p>
      *
      * @param value The value validation is being performed on.
      * @param min   The minimum value.
@@ -294,7 +306,7 @@ public abstract class AbstractNumberValidator extends AbstractFormatValidator {
         if (isAllowFractions()) {
             return value.doubleValue() >= min.doubleValue();
         }
-        return value.longValue() >= min.longValue();
+        return isFinite(value) && isFinite(min) ? compareTo(value, min) >= 0 : value.doubleValue() >= min.doubleValue();
     }
 
     /**

--- a/src/test/java/org/apache/commons/validator/routines/ByteValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/ByteValidatorTest.java
@@ -21,6 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Locale;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -109,6 +111,21 @@ class ByteValidatorTest extends AbstractNumberValidatorTest {
         assertTrue(validator.maxValue(number19, max), "maxValue() < max");
         assertTrue(validator.maxValue(number20, max), "maxValue() = max");
         assertFalse(validator.maxValue(number21, max), "maxValue() > max");
+    }
+
+    /**
+     * The inherited {@link Number}-typed range overloads must compare the exact bound rather than one narrowed to a {@code long}.
+     */
+    @Test
+    void testNumberRangeExactBound() {
+        final AbstractNumberValidator instance = ByteValidator.getInstance();
+        final Number value = Byte.valueOf((byte) 100);
+        // A bound above the long range narrows to a negative long, wrongly reporting 100 as above the maximum.
+        final Number aboveLongMax = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);
+        assertTrue(instance.maxValue(value, aboveLongMax));
+        assertTrue(instance.isInRange(value, BigInteger.ZERO, aboveLongMax));
+        // A fractional bound is not floored: 5 >= 5.5 is false.
+        assertFalse(instance.minValue(Byte.valueOf((byte) 5), new BigDecimal("5.5")));
     }
 
     /**

--- a/src/test/java/org/apache/commons/validator/routines/CurrencyValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/CurrencyValidatorTest.java
@@ -19,8 +19,10 @@ package org.apache.commons.validator.routines;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
 import java.util.Locale;
@@ -43,6 +45,22 @@ class CurrencyValidatorTest {
     protected void setUp() {
         usDollar = new DecimalFormatSymbols(Locale.US).getCurrencySymbol();
         ukPound = new DecimalFormatSymbols(Locale.UK).getCurrencySymbol();
+    }
+
+    /**
+     * The {@link Number}-typed range overloads inherited through {@link BigDecimalValidator} from {@link AbstractNumberValidator} must compare the exact bound,
+     * so a {@code BigInteger} or {@code BigDecimal} bound outside the long range or a fractional bound is not silently truncated.
+     */
+    @Test
+    void testNumberRangeExactBound() {
+        final AbstractNumberValidator instance = CurrencyValidator.getInstance();
+        final Number value = new BigDecimal("100");
+        // A bound above the long range must not narrow to a negative long and wrongly report 100 as above the maximum.
+        final Number aboveLongMax = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);
+        assertTrue(instance.maxValue(value, aboveLongMax));
+        assertTrue(instance.isInRange(value, BigInteger.ZERO, aboveLongMax));
+        // A fractional bound is not floored: 5 >= 5.5 is false.
+        assertFalse(instance.minValue(new BigDecimal("5"), new BigDecimal("5.5")));
     }
 
     /**

--- a/src/test/java/org/apache/commons/validator/routines/FloatValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/FloatValidatorTest.java
@@ -23,6 +23,8 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
@@ -134,6 +136,22 @@ class FloatValidatorTest extends AbstractNumberValidatorTest {
         assertFalse(validator.minValue(Float.NaN, 10), "minValue() NaN");
         // maxValue() with NaN: NaN <= max is always false
         assertFalse(validator.maxValue(Float.NaN, 20), "maxValue() NaN");
+    }
+
+    /**
+     * The {@link Number}-typed range overloads inherited from {@link AbstractNumberValidator} must compare the exact bound, so a {@code BigInteger} or
+     * {@code BigDecimal} bound outside the long range or a fractional bound is not silently truncated.
+     */
+    @Test
+    void testNumberRangeExactBound() {
+        final AbstractNumberValidator instance = FloatValidator.getInstance();
+        final Number value = Float.valueOf(100);
+        // A bound above the long range must not narrow to a negative long and wrongly report 100 as above the maximum.
+        final Number aboveLongMax = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);
+        assertTrue(instance.maxValue(value, aboveLongMax));
+        assertTrue(instance.isInRange(value, BigInteger.ZERO, aboveLongMax));
+        // A fractional bound is not floored: 5 >= 5.5 is false.
+        assertFalse(instance.minValue(Float.valueOf(5), new BigDecimal("5.5")));
     }
 
     /**

--- a/src/test/java/org/apache/commons/validator/routines/IntegerValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/IntegerValidatorTest.java
@@ -21,6 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Locale;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -148,5 +150,20 @@ class IntegerValidatorTest extends AbstractNumberValidatorTest {
         assertFalse(validator.isValid("2147483648"), "2147483648 > max integer");
         assertTrue(validator.isValid("-2147483648"), "-2147483648 is min integer");
         assertFalse(validator.isValid("-2147483649"), "-2147483649 < min integer");
+    }
+
+    /**
+     * The inherited {@link Number}-typed range overloads must compare the exact bound rather than one narrowed to a {@code long}.
+     */
+    @Test
+    void testNumberRangeExactBound() {
+        final AbstractNumberValidator instance = IntegerValidator.getInstance();
+        final Number value = Integer.valueOf(100);
+        // A bound above the long range narrows to a negative long, wrongly reporting 100 as above the maximum.
+        final Number aboveLongMax = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);
+        assertTrue(instance.maxValue(value, aboveLongMax));
+        assertTrue(instance.isInRange(value, BigInteger.ZERO, aboveLongMax));
+        // A fractional bound is not floored: 5 >= 5.5 is false.
+        assertFalse(instance.minValue(Integer.valueOf(5), new BigDecimal("5.5")));
     }
 }

--- a/src/test/java/org/apache/commons/validator/routines/LongValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/LongValidatorTest.java
@@ -21,6 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Locale;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -109,6 +111,28 @@ class LongValidatorTest extends AbstractNumberValidatorTest {
         assertTrue(validator.maxValue(number19, 20), "maxValue() < max");
         assertTrue(validator.maxValue(number20, 20), "maxValue() = max");
         assertFalse(validator.maxValue(number21, 20), "maxValue() > max");
+    }
+
+    /**
+     * The {@link Number}-typed range overloads inherited from {@link AbstractNumberValidator} must compare the exact bound rather than one narrowed to a
+     * {@code long}, so a {@code BigInteger}/{@code BigDecimal} bound outside the long range or a fractional bound is not silently truncated.
+     */
+    @Test
+    void testNumberRangeExactBound() {
+        final AbstractNumberValidator instance = LongValidator.getInstance();
+        final Number value = Long.valueOf(Long.MAX_VALUE);
+        // One above Long.MAX_VALUE narrows to Long.MIN_VALUE, wrongly reporting Long.MAX_VALUE as above the maximum.
+        final Number aboveLongMax = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);
+        assertTrue(instance.maxValue(value, aboveLongMax));
+        assertTrue(instance.isInRange(value, BigInteger.ZERO, aboveLongMax));
+        // A fractional bound is not floored: 5 >= 5.5 is false, 5 <= 5.5 is true.
+        assertFalse(instance.minValue(Long.valueOf(5), Double.valueOf(5.5)));
+        assertFalse(instance.minValue(Long.valueOf(5), new BigDecimal("5.5")));
+        assertTrue(instance.maxValue(Long.valueOf(5), new BigDecimal("5.5")));
+        // A non-finite bound falls back to the double comparison, matching the Big* validators.
+        assertFalse(instance.minValue(value, Double.NaN));
+        assertTrue(instance.maxValue(value, Double.POSITIVE_INFINITY));
+        assertTrue(instance.minValue(value, Double.NEGATIVE_INFINITY));
     }
 
     /**

--- a/src/test/java/org/apache/commons/validator/routines/PercentValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/PercentValidatorTest.java
@@ -19,8 +19,10 @@ package org.apache.commons.validator.routines;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Locale;
 
 import org.junit.jupiter.api.AfterEach;
@@ -49,6 +51,22 @@ class PercentValidatorTest {
     protected void tearDown() {
         Locale.setDefault(originalLocale);
         validator = null;
+    }
+
+    /**
+     * The {@link Number}-typed range overloads inherited through {@link BigDecimalValidator} from {@link AbstractNumberValidator} must compare the exact bound,
+     * so a {@code BigInteger} or {@code BigDecimal} bound outside the long range or a fractional bound is not silently truncated.
+     */
+    @Test
+    void testNumberRangeExactBound() {
+        final AbstractNumberValidator instance = PercentValidator.getInstance();
+        final Number value = new BigDecimal("100");
+        // A bound above the long range must not narrow to a negative long and wrongly report 100 as above the maximum.
+        final Number aboveLongMax = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);
+        assertTrue(instance.maxValue(value, aboveLongMax));
+        assertTrue(instance.isInRange(value, BigInteger.ZERO, aboveLongMax));
+        // A fractional bound is not floored: 5 >= 5.5 is false.
+        assertFalse(instance.minValue(new BigDecimal("5"), new BigDecimal("5.5")));
     }
 
     /**

--- a/src/test/java/org/apache/commons/validator/routines/ShortValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/ShortValidatorTest.java
@@ -21,6 +21,8 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
 import java.util.Locale;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -100,6 +102,21 @@ class ShortValidatorTest extends AbstractNumberValidatorTest {
         assertTrue(validator.maxValue(number19, max), "maxValue() < max");
         assertTrue(validator.maxValue(number20, max), "maxValue() = max");
         assertFalse(validator.maxValue(number21, max), "maxValue() > max");
+    }
+
+    /**
+     * The inherited {@link Number}-typed range overloads must compare the exact bound rather than one narrowed to a {@code long}.
+     */
+    @Test
+    void testNumberRangeExactBound() {
+        final AbstractNumberValidator instance = ShortValidator.getInstance();
+        final Number value = Short.valueOf((short) 100);
+        // A bound above the long range narrows to a negative long, wrongly reporting 100 as above the maximum.
+        final Number aboveLongMax = BigInteger.valueOf(Long.MAX_VALUE).add(BigInteger.ONE);
+        assertTrue(instance.maxValue(value, aboveLongMax));
+        assertTrue(instance.isInRange(value, BigInteger.ZERO, aboveLongMax));
+        // A fractional bound is not floored: 5 >= 5.5 is false.
+        assertFalse(instance.minValue(Short.valueOf((short) 5), new BigDecimal("5.5")));
     }
 
     /**


### PR DESCRIPTION
The DoubleValidator range fix in #410 left the same narrowing in the shared parent. `AbstractNumberValidator.minValue(Number, Number)` and `maxValue(Number, Number)` fall back to `value.longValue()` against `min.longValue()` on the integer branch, and `ByteValidator`, `ShortValidator`, `IntegerValidator` and `LongValidator` inherit that branch without overriding it, so a bound that does not fit in a long is mangled before the comparison ever happens. `LongValidator.maxValue(Long.MAX_VALUE, 2^63 held as a BigInteger)` narrows the bound to `Long.MIN_VALUE` and reports the in-range value as over the maximum, while a fractional bound such as `minValue(5, 5.5)` is floored to 5 and wrongly passes. The visible behaviour is a validator quietly comparing against the wrong bound whenever a small integer value meets a `BigInteger`, `BigDecimal` or fractional limit, which is easy to miss because no error is raised.

The `BigInteger`, `BigDecimal` and `Double` overloads already compare the operands exactly and keep the `doubleValue()` fallback for a non-finite bound, so I put the same treatment on the parent's integer branch rather than repeat an override in all four subclasses. Sitting the fix in the shared base keeps the `NaN` and infinity handling identical across the hierarchy and avoids a fifth copy of the comparison. Each of the four affected validator tests gets a regression that fails on the old narrowing branch and passes now.

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
