### PR TITLE
Reject fractional scientific notation in ShortValidator

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/ShortValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/ShortValidator.java
@@ -195,13 +195,15 @@ public class ShortValidator extends AbstractNumberValidator {
     @Override
     protected Object processParsedValue(final Object value, final Format formatter) {
 
-        final long longValue = ((Number) value).longValue();
-
-        if (longValue < Short.MIN_VALUE ||
-            longValue > Short.MAX_VALUE) {
-            return null;
+        // Parsed value will be Long if it fits in a long and is not fractional
+        if (value instanceof Long) {
+            final long longValue = ((Long) value).longValue();
+            if (longValue >= Short.MIN_VALUE &&
+                longValue <= Short.MAX_VALUE) {
+                return Short.valueOf((short) longValue);
+            }
         }
-        return Short.valueOf((short) longValue);
+        return null;
     }
 
     /**

--- a/src/test/java/org/apache/commons/validator/routines/ShortValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/ShortValidatorTest.java
@@ -87,6 +87,22 @@ class ShortValidatorTest extends AbstractNumberValidatorTest {
     }
 
     /**
+     * A value whose fractional part is expressed through a negative exponent rather than a decimal point (for example
+     * {@code "15E-1"} for 1.5) is parsed to a fractional {@code Double}, not a {@code Long}, because {@code parseIntegerOnly}
+     * only stops at the decimal separator. It must be rejected like any other non-integer, matching {@link ByteValidator},
+     * {@link IntegerValidator} and {@link LongValidator}, rather than being truncated towards zero.
+     */
+    @Test
+    void testFractionalScientificNotation() {
+        final ShortValidator validator = ShortValidator.getInstance();
+        assertNull(validator.validate("15E-1", Locale.US), "validate(15E-1)");
+        assertFalse(validator.isValid("15E-1", Locale.US), "isValid(15E-1)");
+        assertNull(validator.validate("5E-1", Locale.US), "validate(5E-1)");
+        assertNull(validator.validate("-15E-1", Locale.US), "validate(-15E-1)");
+        assertNull(validator.validate("1E-100", Locale.US), "validate(1E-100)");
+    }
+
+    /**
      * Test Short Range/Min/Max
      */
     @Test


### PR DESCRIPTION
ShortValidator.processParsedValue narrowed the parsed value with `((Number) value).longValue()` and then range-checked it, unlike `ByteValidator`, `IntegerValidator` and `LongValidator` which first check the value is a `Long`. A `NumberFormat` with `parseIntegerOnly` set only stops at the decimal separator, so a fractional value written with a negative exponent and no decimal point, such as `15E-1` (1.5) or `1E-100`, is still recognised and parses in full to a fractional `Double` rather than a `Long`. `longValue()` then truncates it towards zero, so `validate("15E-1")` returns `1` and `isValid("15E-1")` reports `true`, while the three sibling validators return `null` for the same input. Plain decimal fractions like `1.5` are already rejected, so the exponent and decimal forms behave inconsistently and a caller is handed a silently truncated value it never entered.

The fix guards on `value instanceof Long` before the conversion, so a non-`Long` parse result (a fractional `Double`, or one outside the long range) now returns `null`, matching the other three integer validators and their "Parsed value will be Long if it fits in a long and is not fractional" comment. Keeping the check inside `processParsedValue` means every `validate`/`isValid` overload inherits the corrected behaviour without callers having to pre-screen their input. A `ShortValidatorTest` case covers it and fails on the current code (`validate` returns `1`) before passing with the guard in place.

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
