### PR TITLE
Reject fractional exponent input in BigIntegerValidator

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/BigIntegerValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/BigIntegerValidator.java
@@ -17,6 +17,7 @@
 
 package org.apache.commons.validator.routines;
 
+import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.text.DecimalFormat;
 import java.text.Format;
@@ -204,7 +205,14 @@ public class BigIntegerValidator extends AbstractNumberValidator {
      */
     @Override
     protected Object processParsedValue(final Object value, final Format formatter) {
-        return toBigInteger(value);
+        final BigDecimal parsed = toBigDecimal(value);
+        // parseIntegerOnly only stops at the decimal separator, so a fractional value written with a negative exponent and no decimal point (for example
+        // "15E-1" for 1.5) is consumed in full and, because getFormat enables setParseBigDecimal, arrives here as a fractional BigDecimal. Reject it instead
+        // of flooring it with toBigInteger, matching ByteValidator, IntegerValidator and LongValidator, which return null for the same input.
+        if (parsed.signum() != 0 && parsed.stripTrailingZeros().scale() > 0) {
+            return null;
+        }
+        return parsed.toBigInteger();
     }
 
     /**

--- a/src/test/java/org/apache/commons/validator/routines/BigIntegerValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/BigIntegerValidatorTest.java
@@ -123,6 +123,28 @@ class BigIntegerValidatorTest extends AbstractNumberValidatorTest {
     }
 
     /**
+     * A fractional value written with a negative exponent and no decimal point (for example "15E-1" for 1.5) is consumed in full because parseIntegerOnly only
+     * stops at the decimal separator, so it arrives as a fractional BigDecimal and was floored by toBigInteger. It must be rejected instead, matching
+     * ByteValidator, IntegerValidator and LongValidator, which return null for the same input.
+     */
+    @Test
+    void testRejectFractionalExponent() {
+        final BigIntegerValidator instance = BigIntegerValidator.getInstance();
+        assertNull(instance.validate("15E-1")); // 1.5, was floored to 1
+        assertNull(instance.validate("5E-1")); // 0.5, was floored to 0
+        assertNull(instance.validate("5E-100"));
+        // the primitive integer validators already reject these
+        assertNull(IntegerValidator.getInstance().validate("15E-1"));
+        assertNull(LongValidator.getInstance().validate("15E-1"));
+        // a whole number written with an exponent stays valid
+        assertEquals(new BigInteger("100"), instance.validate("1E2"));
+        // the lenient (non-strict) validator still truncates trailing fraction digits
+        final BigIntegerValidator lenient = new BigIntegerValidator(false, 0);
+        assertEquals(new BigInteger("1234"), lenient.validate("1,234.5"));
+        assertNull(lenient.validate("15E-1"));
+    }
+
+    /**
      * Test BigInteger Range/Min/Max
      */
     @Test


### PR DESCRIPTION
Following up on the request to look at other BigInteger/BigDecimal to integer conversions: BigIntegerValidator.validate("15E-1") returns 1 and validate("5E-1") returns 0. The integer-only format sets parseIntegerOnly, but that flag only stops at the decimal separator, so a fractional value written with a negative exponent and no decimal point is consumed in full. Since getFormat enables setParseBigDecimal, it reaches processParsedValue as a fractional BigDecimal (1.5, 0.5) and toBigInteger silently floors it towards zero. ByteValidator, IntegerValidator and LongValidator all return null for the same input because their parse yields a non-Long they reject, so BigInteger was the odd one out and quietly returned a different value than supplied.

Reject a parsed value that carries a fractional part rather than truncating it, keeping the check in processParsedValue where the conversion happens. Whole numbers, exponent forms such as 1E2, integers beyond the long range and the lenient non-strict truncation of trailing fraction digits (1,234.5 to 1234, where parseIntegerOnly does stop at the dot) are unchanged. Added a regression test that fails before and passes after.