### PR TITLE
Handle Float operand in AbstractNumberValidator.toBigDecimal

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/AbstractNumberValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/AbstractNumberValidator.java
@@ -94,6 +94,9 @@ public abstract class AbstractNumberValidator extends AbstractFormatValidator {
         if (value instanceof Double) {
             return BigDecimal.valueOf(((Double) value).doubleValue());
         }
+        if (value instanceof Float) {
+            return BigDecimal.valueOf(((Float) value).doubleValue());
+        }
         if (value instanceof BigDecimal) {
             return (BigDecimal) value;
         }

--- a/src/test/java/org/apache/commons/validator/routines/BigIntegerValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/BigIntegerValidatorTest.java
@@ -221,6 +221,27 @@ class BigIntegerValidatorTest extends AbstractNumberValidatorTest {
     }
 
     /**
+     * A {@link Float} bound must be compared at its real magnitude. The bound is converted through {@link AbstractNumberValidator#toBigDecimal}, which had no
+     * {@code Float} branch, so a {@code Float} fell through to {@code new BigDecimal(value.toString())}; {@code Float.toString} emits only the digits needed to
+     * round-trip the float, so the bound was read at a coarser value than it actually holds and a value sitting between the two magnitudes was mis-ranged.
+     */
+    @Test
+    void testNumberRangeFloatBound() {
+        final AbstractNumberValidator instance = BigIntegerValidator.getInstance();
+        final Float bound = Float.valueOf(1e20f);
+        final BigInteger exact = new BigDecimal(bound.doubleValue()).toBigInteger(); // what the float really holds
+        final BigInteger truncated = new BigDecimal(bound.toString()).toBigInteger(); // what Float.toString shows
+        final BigInteger between = truncated.add(BigInteger.ONE); // above the printed value, below the real float
+        // guard the fixture: the float prints smaller than it is
+        assertTrue(between.compareTo(truncated) > 0 && between.compareTo(exact) < 0);
+        assertTrue(instance.maxValue(between, bound), "value below the real float is within the maximum");
+        assertFalse(instance.minValue(between, bound), "value below the real float is below the minimum");
+        final BigInteger above = exact.add(BigInteger.ONE);
+        assertFalse(instance.maxValue(above, bound), "value above the real float exceeds the maximum");
+        assertTrue(instance.minValue(above, bound), "value above the real float meets the minimum");
+    }
+
+    /**
      * A non-finite {@link Double} bound must not be routed through {@link BigDecimal}, which cannot represent {@code NaN} or an infinity. The {@link Number}
      * overloads previously converted every bound to a {@code BigDecimal} and so threw {@code NumberFormatException} for such a bound, whereas the sibling
      * {@link BigDecimalValidator} already handled it. The behavior now matches: a {@code NaN} bound is never satisfied, and an infinity is an open bound.

--- a/src/test/java/org/apache/commons/validator/routines/BigIntegerValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/BigIntegerValidatorTest.java
@@ -239,12 +239,26 @@ class BigIntegerValidatorTest extends AbstractNumberValidatorTest {
         final BigInteger above = exact.add(BigInteger.ONE);
         assertFalse(instance.maxValue(above, bound), "value above the real float exceeds the maximum");
         assertTrue(instance.minValue(above, bound), "value above the real float meets the minimum");
+
+        // mirrored negative bound: the float prints closer to zero than the value it really holds
+        final Float negBound = Float.valueOf(-1e20f);
+        final BigInteger negExact = new BigDecimal(negBound.doubleValue()).toBigInteger(); // what the float really holds
+        final BigInteger negTruncated = new BigDecimal(negBound.toString()).toBigInteger(); // what Float.toString shows
+        final BigInteger negBetween = negTruncated.subtract(BigInteger.ONE); // below the printed value, above the real float
+        // guard the fixture: the value sits between the two magnitudes
+        assertTrue(negBetween.compareTo(negTruncated) < 0 && negBetween.compareTo(negExact) > 0);
+        assertFalse(instance.maxValue(negBetween, negBound), "value above the real negative float exceeds the maximum");
+        assertTrue(instance.minValue(negBetween, negBound), "value above the real negative float meets the minimum");
+        final BigInteger negBelow = negExact.subtract(BigInteger.ONE);
+        assertTrue(instance.maxValue(negBelow, negBound), "value below the real negative float is within the maximum");
+        assertFalse(instance.minValue(negBelow, negBound), "value below the real negative float is below the minimum");
     }
 
     /**
      * A non-finite {@link Double} bound must not be routed through {@link BigDecimal}, which cannot represent {@code NaN} or an infinity. The {@link Number}
      * overloads previously converted every bound to a {@code BigDecimal} and so threw {@code NumberFormatException} for such a bound, whereas the sibling
-     * {@link BigDecimalValidator} already handled it. The behavior now matches: a {@code NaN} bound is never satisfied, and an infinity is an open bound.
+     * {@link BigDecimalValidator} already handled it. The behavior now matches: a {@code NaN} bound is never satisfied, and an infinity is an open bound. A
+     * {@link Float} carries the same non-finite values and takes the same guarded path, so it is delegated to the double comparison rather than converted.
      */
     @Test
     void testNumberRangeNonFiniteBound() {
@@ -279,6 +293,13 @@ class BigIntegerValidatorTest extends AbstractNumberValidatorTest {
         assertFalse(instance.minValue(negInf, posInf));
         assertFalse(instance.maxValue(posInf, nan));
         assertFalse(instance.minValue(posInf, nan));
+        // a non-finite Float bound is caught by the same isFinite guard and never reaches toBigDecimal
+        assertFalse(instance.maxValue(value, Float.NaN));
+        assertFalse(instance.minValue(value, Float.NaN));
+        assertTrue(instance.maxValue(value, Float.POSITIVE_INFINITY));
+        assertTrue(instance.minValue(value, Float.NEGATIVE_INFINITY));
+        assertFalse(instance.minValue(value, Float.POSITIVE_INFINITY));
+        assertFalse(instance.maxValue(value, Float.NEGATIVE_INFINITY));
     }
 
     /**


### PR DESCRIPTION
**Float bound read at the wrong magnitude in the number range checks**

While extending the exact-bound range checks to a `Float` limit I found `BigIntegerValidator.getInstance().maxValue(new BigInteger("100000000000000000001"), 1e20f)` returning false, even though the float `1e20f` actually holds 100000002004087734272 and the value sits below it. The `Number` range overloads convert both operands through `AbstractNumberValidator.toBigDecimal` before comparing, and that helper branches on `Long`, `Double`, `BigDecimal` and `BigInteger` but has no `Float` case, so a `Float` drops to the final `new BigDecimal(value.toString())`. `Float.toString` emits only the digits needed to round-trip the value, so the bound is rebuilt from "1.0E20" and compared as 10^20 rather than its real magnitude, and anything between the two is mis-ranged.

Root cause is the missing branch, so I widened a `Float` through `doubleValue()` and used `BigDecimal.valueOf`, mirroring the neighbouring `Double` branch, and the operand is now compared at the value it truly holds. If left as is a value near a float limit is silently admitted or rejected across `BigIntegerValidator`, `BigDecimalValidator` and `DoubleValidator`, and `toBigInteger` carries the same skew since it routes through `toBigDecimal`. The regression test in `BigIntegerValidatorTest` derives its fixture from the float itself so it does not lean on a hand-written constant.