### PR TITLE
Reject format code points in DomainValidator.unicodeToASCII

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/DomainValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/DomainValidator.java
@@ -1945,6 +1945,17 @@ public class DomainValidator implements Serializable {
         if (isOnlyASCII(input)) { // skip possibly expensive processing
             return input;
         }
+        // IDN.toASCII silently drops default-ignorable and format code points (soft hyphen,
+        // zero-width spaces, the byte order mark, ...) during nameprep, so a host carrying one
+        // would convert to a clean label and validate. Those code points are not legal in a host
+        // name, so keep the original here and let the label regex reject it.
+        for (int i = 0; i < input.length();) {
+            final int codePoint = input.codePointAt(i);
+            if (Character.getType(codePoint) == Character.FORMAT) {
+                return input;
+            }
+            i += Character.charCount(codePoint);
+        }
         try {
             final String ascii = IDN.toASCII(input);
             if (IDNBUGHOLDER.IDN_TOASCII_PRESERVES_TRAILING_DOTS) {

--- a/src/test/java/org/apache/commons/validator/routines/DomainValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/DomainValidatorTest.java
@@ -460,6 +460,18 @@ public class DomainValidatorTest {
     }
 
     @Test
+    void testIDNFormatCodePoints() {
+        // IDN.toASCII strips default-ignorable / format code points during nameprep, which would
+        // otherwise let an invisible character slip into a host that validates as the clean label.
+        // Those code points are not legal in a host name and must be rejected.
+        assertFalse(validator.isValid("exa\u00ADmple.com"), "soft hyphen shouldn't validate");
+        assertFalse(validator.isValid("exa\u200Bmple.com"), "zero-width space shouldn't validate");
+        assertFalse(validator.isValid("exa\u200Dmple.com"), "zero-width joiner shouldn't validate");
+        assertFalse(validator.isValid("\uFEFFexample.com"), "byte order mark shouldn't validate");
+        assertTrue(validator.isValid("www.b\u00fccher.ch"), "b\u00fccher.ch should still validate");
+    }
+
+    @Test
     void testIDNJava6OrLater() {
         // xn--d1abbgf6aiiy.xn--p1ai http://президент.рф
         assertTrue(validator.isValid("www.b\u00fccher.ch"), "b\u00fccher.ch should validate");


### PR DESCRIPTION
I was checking how DomainValidator handles non-ASCII hosts and found unicodeToASCII passes the input straight to java.net.IDN.toASCII, whose nameprep step silently deletes default-ignorable and format code points before the label regex runs. A host carrying a soft hyphen, a zero-width space or joiner, or a byte order mark therefore collapses to a clean label and validates: isValid("exa​mple.com") and isValid("﻿example.com") both return true, and UrlValidator.isValidAuthority shares the converter so it behaves the same way.

The risk is that two byte-distinct strings validate as the same host, which is a spoofing vector and quietly poisons any allow-list built from validated input. None of these code points are legal in an RFC 1123 host name, and IDN's IDNA2003 normalisation never keeps one in a real label, so the fix scans the input in unicodeToASCII and returns it unconverted when it holds a Unicode FORMAT code point, leaving the existing label regex to reject it. Keeping the guard in the shared converter fixes DomainValidator and UrlValidator in one place rather than each caller, and legitimate IDN input is unaffected because its letters are not format characters.