### PR TITLE
Allow userinfo before a bracketed IPv6 host in isValidAuthority

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/UrlValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/UrlValidator.java
@@ -133,9 +133,10 @@ public class UrlValidator implements Serializable {
             USERINFO_CHARS_REGEX + "+" + // At least one character for the name
             "(?::" + USERINFO_CHARS_REGEX + "*)?@"; // colon and password may be absent
 
+    // Optional userinfo ("user:pass@") precedes the host so it may come before either host form: a bracketed IPv6
+    // literal (group 1) or a hostname/IPv4 host (group 2). Group 3 is the port, group 4 any trailing remainder.
     private static final String AUTHORITY_REGEX =
-            "(?:\\[(" + IPV6_REGEX + ")\\]|(?:(?:" + USERINFO_FIELD_REGEX + ")?([" + AUTHORITY_CHARS_REGEX + "]*)))(?::(\\d*))?(.*)?";
-    //             1                         for example, user:pass@           2                                       3       4
+            "(?:" + USERINFO_FIELD_REGEX + ")?(?:\\[(" + IPV6_REGEX + ")\\]|([" + AUTHORITY_CHARS_REGEX + "]*))(?::(\\d*))?(.*)?";
     private static final Pattern AUTHORITY_PATTERN = Pattern.compile(AUTHORITY_REGEX);
 
     private static final int PARSE_AUTHORITY_IPV6 = 1;

--- a/src/test/java/org/apache/commons/validator/routines/UrlValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/UrlValidatorTest.java
@@ -184,6 +184,19 @@ public class UrlValidatorTest {
         assertFalse(urlValidator.isValidAuthority("[::1]:65536"));
     }
 
+    @Test
+    void testIpv6Userinfo() {
+        final UrlValidator urlValidator = new UrlValidator();
+        // userinfo is allowed before a bracketed IPv6 host, not only before a hostname/IPv4 host
+        assertTrue(urlValidator.isValid("http://user@[::1]/"));
+        assertTrue(urlValidator.isValid("http://user:pass@[2001:db8::1]:8080/index.html"));
+        assertTrue(urlValidator.isValidAuthority("user@[::1]"));
+        assertTrue(urlValidator.isValidAuthority("user:pass@[::1]:65535"));
+        // the host and port checks still apply through the userinfo path
+        assertFalse(urlValidator.isValid("http://user@[::ffff:129.144.52.999]/"));
+        assertFalse(urlValidator.isValidAuthority("user@[::1]:65536"));
+    }
+
     @ParameterizedTest
     // @formatter:off
     @ValueSource(strings = {


### PR DESCRIPTION
UrlValidator.isValidAuthority rejects an authority that carries userinfo before a bracketed IPv6 host, so `http://user@[::1]/` and `http://user:pass@[2001:db8::1]:8080/` come back invalid. The same host without the credentials (`http://[::1]/`) validates, and userinfo before a hostname (`http://user@example.com/`) validates, so the two accepted shapes ought to combine; `java.net.URI` parses `user@[::1]` without complaint and RFC 3986 §3.2 places the optional userinfo before a host that may itself be a bracketed IPv6 literal. Tracing AUTHORITY_PATTERN against `user@[::1]` showed the host group coming back empty with `[::1]` captured in the trailing "extra" group, which is what fails the match.

The cause is that AUTHORITY_REGEX only offered the userinfo prefix inside the reg-name/IPv4 alternative, never before the `\[(IPv6)\]` alternative, so the userinfo branch consumed `user@` and then matched an empty host. I lifted the userinfo group out of the host alternation so it precedes either host form. The capture-group numbers stay put because USERINFO_FIELD_REGEX contains no capturing group, so the IPv6, host, port and extra groups isValidAuthority reads still line up, and the existing IPv6 content and port-range checks keep running through the userinfo path. Left as-is, anything relying on this to admit authenticated IPv6 URLs quietly treats valid addresses as invalid.
