### PR TITLE
Reject control characters in EmailValidator local part

### DIFF
--- a/src/main/java/org/apache/commons/validator/EmailValidator.java
+++ b/src/main/java/org/apache/commons/validator/EmailValidator.java
@@ -43,9 +43,9 @@ import org.apache.commons.validator.routines.InetAddressValidator;
 @Deprecated
 public class EmailValidator {
 
-    private static final String SPECIAL_CHARS = "\\p{Cntrl}\\(\\)<>@,;:'\\\\\\\"\\.\\[\\]";
+    private static final String SPECIAL_CHARS = "\\p{Cc}\\(\\)<>@,;:'\\\\\\\"\\.\\[\\]";
     private static final String VALID_CHARS = "[^\\s" + SPECIAL_CHARS + "]";
-    private static final String QUOTED_USER = "(\"[^\"]*\")";
+    private static final String QUOTED_USER = "(\"[^\"\\p{Cc}]*\")";
     private static final String ATOM = VALID_CHARS + '+';
     private static final String WORD = "((" + VALID_CHARS + "|')+|" + QUOTED_USER + ")";
 

--- a/src/main/java/org/apache/commons/validator/routines/EmailValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/EmailValidator.java
@@ -36,9 +36,9 @@ public class EmailValidator implements Serializable {
 
     private static final long serialVersionUID = 1705927040799295880L;
 
-    private static final String SPECIAL_CHARS = "\\p{Cntrl}\\(\\)<>@,;:'\\\\\\\"\\.\\[\\]";
-    private static final String VALID_CHARS = "(\\\\.)|[^\\s" + SPECIAL_CHARS + "]";
-    private static final String QUOTED_USER = "(\"(\\\\\"|[^\"])*\")";
+    private static final String SPECIAL_CHARS = "\\p{Cc}\\(\\)<>@,;:'\\\\\\\"\\.\\[\\]";
+    private static final String VALID_CHARS = "(\\\\[^\\p{Cc}])|[^\\s" + SPECIAL_CHARS + "]";
+    private static final String QUOTED_USER = "(\"(\\\\\"|[^\"\\p{Cc}])*\")";
     private static final String WORD = "((" + VALID_CHARS + "|')+|" + QUOTED_USER + ")";
 
     private static final String EMAIL_REGEX = "^(.+)@(\\S+)$";

--- a/src/test/java/org/apache/commons/validator/routines/EmailValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/EmailValidatorTest.java
@@ -401,6 +401,26 @@ public class EmailValidatorTest {
     }
 
     /**
+     * Tests that a control character is rejected in the local part however it is introduced: inside a quoted string, as a quoted-pair, and in the C1 range
+     * (U+0080-U+009F). {@link #testEmailWithControlChars()} only exercises unquoted C0/DEL, which the ASCII-only {@code \p{Cntrl}} class already excluded; the
+     * quoted string accepted any character and {@code \p{Cntrl}} let the C1 controls through.
+     */
+    @Test
+    void testEmailWithControlCharsInQuotedStringAndC1Range() {
+        for (int c = 0; c <= 0x9F; c++) {
+            if (Character.getType(c) != Character.CONTROL) {
+                continue;
+            }
+            final char ch = (char) c;
+            assertFalse(validator.isValid("\"foo" + ch + "bar\"@domain.com"), "quoted control char " + c);
+            assertFalse(validator.isValid("foo\\" + ch + "bar@domain.com"), "quoted-pair control char " + c);
+            if (c >= 0x80) {
+                assertFalse(validator.isValid("foo" + ch + "bar@domain.com"), "C1 control char " + c);
+            }
+        }
+    }
+
+    /**
      * <p>
      * Tests the e-mail validation with a dash in the address.
      * </p>


### PR DESCRIPTION
`testEmailWithControlChars` already asserts that control characters are rejected in the local part, but it only exercises unquoted C0 and DEL. Reading the local-part grammar, two other routes survive: the quoted-string production allows `[^"]`, which admits any control character, so `"ab"@example.com` validates; and the unquoted atom excludes controls through `\p{Cntrl}`, which in Java is ASCII-only (`[\x00-\x1F\x7F]`), so the C1 block U+0080 to U+009F passes, as does a backslash-escaped control via the `(\\.)` alternative.

The fix swaps that exclusion for `\p{Cc}`, the Unicode Control general category covering C0, DEL and C1, and applies it to all three local-part productions: the unquoted atom, its quoted-pair, and the quoted string. Keeping the check in the grammar closes every route at once rather than leaving each caller to pre-scan the address. The deprecated `org.apache.commons.validator.EmailValidator` carries the same construct in `isValidUser` and takes the identical change; left unfixed, a NUL or other control byte rides through inside a value the caller treats as a validated address.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
