### PR TITLE
Reject fractional input in GenericTypeValidator integer helpers

### DIFF
--- a/src/main/java/org/apache/commons/validator/GenericTypeValidator.java
+++ b/src/main/java/org/apache/commons/validator/GenericTypeValidator.java
@@ -66,9 +66,15 @@ public class GenericTypeValidator implements Serializable {
         if (value != null) {
             final ParsePosition pos = new ParsePosition(0);
             final Number num = getIntegerOnlyFormat(locale).parse(value, pos);
-            // If there was no error and we used the whole string
-            if (pos.getErrorIndex() == -1 && pos.getIndex() == value.length() && num.doubleValue() >= Byte.MIN_VALUE && num.doubleValue() <= Byte.MAX_VALUE) {
-                result = Byte.valueOf(num.byteValue());
+            // parseIntegerOnly only stops at the decimal separator, so a fractional value written with a negative
+            // exponent and no decimal point (for example "15E-1" for 1.5) is consumed in full and returned as a
+            // Double; byteValue() would floor it. NumberFormat returns a Long only for a non-fractional value in
+            // long range, so guard on that before the byte range check, matching formatLong.
+            if (pos.getIndex() == value.length() && num instanceof Long) {
+                final long longValue = (Long) num;
+                if (longValue >= Byte.MIN_VALUE && longValue <= Byte.MAX_VALUE) {
+                    result = Byte.valueOf((byte) longValue);
+                }
             }
         }
         return result;
@@ -269,10 +275,15 @@ public class GenericTypeValidator implements Serializable {
             final NumberFormat formatter = getIntegerOnlyFormat(locale);
             final ParsePosition pos = new ParsePosition(0);
             final Number num = formatter.parse(value, pos);
-            // If there was no error and we used the whole string
-            if (pos.getErrorIndex() == -1 && pos.getIndex() == value.length() && num.doubleValue() >= Integer.MIN_VALUE
-                    && num.doubleValue() <= Integer.MAX_VALUE) {
-                result = Integer.valueOf(num.intValue());
+            // parseIntegerOnly only stops at the decimal separator, so a fractional value written with a negative
+            // exponent and no decimal point (for example "15E-1" for 1.5) is consumed in full and returned as a
+            // Double; intValue() would floor it. NumberFormat returns a Long only for a non-fractional value in
+            // long range, so guard on that before the int range check, matching formatLong.
+            if (pos.getIndex() == value.length() && num instanceof Long) {
+                final long longValue = (Long) num;
+                if (longValue >= Integer.MIN_VALUE && longValue <= Integer.MAX_VALUE) {
+                    result = Integer.valueOf((int) longValue);
+                }
             }
         }
         return result;
@@ -352,9 +363,15 @@ public class GenericTypeValidator implements Serializable {
             final NumberFormat formatter = getIntegerOnlyFormat(locale);
             final ParsePosition pos = new ParsePosition(0);
             final Number num = formatter.parse(value, pos);
-            // If there was no error and we used the whole string
-            if (pos.getErrorIndex() == -1 && pos.getIndex() == value.length() && num.doubleValue() >= Short.MIN_VALUE && num.doubleValue() <= Short.MAX_VALUE) {
-                result = Short.valueOf(num.shortValue());
+            // parseIntegerOnly only stops at the decimal separator, so a fractional value written with a negative
+            // exponent and no decimal point (for example "15E-1" for 1.5) is consumed in full and returned as a
+            // Double; shortValue() would floor it. NumberFormat returns a Long only for a non-fractional value in
+            // long range, so guard on that before the short range check, matching formatLong.
+            if (pos.getIndex() == value.length() && num instanceof Long) {
+                final long longValue = (Long) num;
+                if (longValue >= Short.MIN_VALUE && longValue <= Short.MAX_VALUE) {
+                    result = Short.valueOf((short) longValue);
+                }
             }
         }
         return result;

--- a/src/test/java/org/apache/commons/validator/GenericTypeValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/GenericTypeValidatorTest.java
@@ -134,6 +134,26 @@ class GenericTypeValidatorTest extends AbstractCommonTest {
     }
 
     /**
+     * Tests that the integer-typed locale format methods reject a fractional value instead of truncating it. A value written with a negative exponent and no
+     * decimal point (for example "15E-1" for 1.5) is consumed in full by the integer-only format and used to be floored to a non-null result, unlike
+     * {@link GenericTypeValidator#formatLong(String, Locale)}.
+     */
+    @Test
+    void testIntegerLocaleFractional() {
+        assertNull(GenericTypeValidator.formatByte("15E-1", Locale.US));
+        assertNull(GenericTypeValidator.formatByte("5E-1", Locale.US));
+        assertEquals(Byte.valueOf((byte) 100), GenericTypeValidator.formatByte("1E2", Locale.US));
+
+        assertNull(GenericTypeValidator.formatShort("15E-1", Locale.US));
+        assertNull(GenericTypeValidator.formatShort("5E-1", Locale.US));
+        assertEquals(Short.valueOf((short) 100), GenericTypeValidator.formatShort("1E2", Locale.US));
+
+        assertNull(GenericTypeValidator.formatInt("15E-1", Locale.US));
+        assertNull(GenericTypeValidator.formatInt("5E-1", Locale.US));
+        assertEquals(Integer.valueOf(100), GenericTypeValidator.formatInt("1E2", Locale.US));
+    }
+
+    /**
      * Tests the byte validation.
      */
     @Test

--- a/src/test/java/org/apache/commons/validator/GenericTypeValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/GenericTypeValidatorTest.java
@@ -134,20 +134,36 @@ class GenericTypeValidatorTest extends AbstractCommonTest {
     }
 
     /**
-     * Tests that the integer-typed locale format methods reject a fractional value instead of truncating it. A value written with a negative exponent and no
-     * decimal point (for example "15E-1" for 1.5) is consumed in full by the integer-only format and used to be floored to a non-null result, unlike
-     * {@link GenericTypeValidator#formatLong(String, Locale)}.
+     * Tests that {@link GenericTypeValidator#formatByte(String, Locale)} rejects a fractional value instead of truncating it. A value written with a negative
+     * exponent and no decimal point (for example "15E-1" for 1.5) is consumed in full by the integer-only format and used to be floored to a non-null result,
+     * unlike {@link GenericTypeValidator#formatLong(String, Locale)}.
      */
     @Test
-    void testIntegerLocaleFractional() {
+    void testByteLocaleFractional() {
         assertNull(GenericTypeValidator.formatByte("15E-1", Locale.US));
         assertNull(GenericTypeValidator.formatByte("5E-1", Locale.US));
         assertEquals(Byte.valueOf((byte) 100), GenericTypeValidator.formatByte("1E2", Locale.US));
+    }
 
+    /**
+     * Tests that {@link GenericTypeValidator#formatShort(String, Locale)} rejects a fractional value instead of truncating it. A value written with a negative
+     * exponent and no decimal point (for example "15E-1" for 1.5) is consumed in full by the integer-only format and used to be floored to a non-null result,
+     * unlike {@link GenericTypeValidator#formatLong(String, Locale)}.
+     */
+    @Test
+    void testShortLocaleFractional() {
         assertNull(GenericTypeValidator.formatShort("15E-1", Locale.US));
         assertNull(GenericTypeValidator.formatShort("5E-1", Locale.US));
         assertEquals(Short.valueOf((short) 100), GenericTypeValidator.formatShort("1E2", Locale.US));
+    }
 
+    /**
+     * Tests that {@link GenericTypeValidator#formatInt(String, Locale)} rejects a fractional value instead of truncating it. A value written with a negative
+     * exponent and no decimal point (for example "15E-1" for 1.5) is consumed in full by the integer-only format and used to be floored to a non-null result,
+     * unlike {@link GenericTypeValidator#formatLong(String, Locale)}.
+     */
+    @Test
+    void testIntLocaleFractional() {
         assertNull(GenericTypeValidator.formatInt("15E-1", Locale.US));
         assertNull(GenericTypeValidator.formatInt("5E-1", Locale.US));
         assertEquals(Integer.valueOf(100), GenericTypeValidator.formatInt("1E2", Locale.US));


### PR DESCRIPTION
Following the formatLong range-check fix, formatByte, formatInt and formatShort (the String, Locale overloads) still range-check the parsed number with num.doubleValue() and then narrow it with byteValue()/intValue()/shortValue(). The integer-only NumberFormat only stops parsing at the decimal separator, so a fractional value written with a negative exponent and no decimal point is consumed whole and handed back as a Double: under Locale.US "15E-1" (1.5) satisfies the double bounds and byteValue() floors it, so formatByte returns 1 and formatInt("5E-1") returns 0 instead of null. That earlier fix observed the sibling bounds are exact as doubles, which rules out the long magnitude gap but not this fractional one, so the three helpers report an integer the caller never entered.

Guard each of the three on num instanceof Long before the per-type range check, which NumberFormat returns only for a non-fractional value in long range, matching formatLong and routines.Byte/Short/IntegerValidator. Keeping the decision inside the conversion helper means a value that was never integral comes back as null rather than a silently truncated one. Added GenericTypeValidatorTest#testIntegerLocaleFractional, which fails on the current code and passes with the change.