### PR TITLE
Reject leading and trailing label hyphens in DomainValidator unicodeToASCII

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/DomainValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/DomainValidator.java
@@ -1920,6 +1920,38 @@ public class DomainValidator implements Serializable {
     }
 
     /*
+     * Tests whether any label in the input begins or ends with an ASCII hyphen, which is not
+     * permitted in a host name label. Labels are separated by the dot characters recognized in
+     * RFC 3490 section 3.1.
+     */
+    private static boolean hasLabelBoundaryHyphen(final String input) {
+        boolean labelStart = true;
+        for (int i = 0; i < input.length(); i++) {
+            final char ch = input.charAt(i);
+            if (isLabelSeparator(ch)) {
+                if (i > 0 && input.charAt(i - 1) == '-') {
+                    return true; // label ends with a hyphen
+                }
+                labelStart = true;
+            } else {
+                if (labelStart && ch == '-') {
+                    return true; // label begins with a hyphen
+                }
+                labelStart = false;
+            }
+        }
+        final int last = input.length() - 1;
+        return last >= 0 && input.charAt(last) == '-';
+    }
+
+    /*
+     * Tests whether the character is one of the label separators recognized in RFC 3490 section 3.1.
+     */
+    private static boolean isLabelSeparator(final char ch) {
+        return ch == '.' || ch == '\u3002' || ch == '\uFF0E' || ch == '\uFF61';
+    }
+
+    /*
      * Tests whether input contains only ASCII. Treats null as all ASCII.
      */
     private static boolean isOnlyASCII(final String input) {
@@ -1955,6 +1987,15 @@ public class DomainValidator implements Serializable {
                 return input;
             }
             i += Character.charCount(codePoint);
+        }
+        // A label must not begin or end with a hyphen (RFC 1123, and RFC 5891 for IDN labels).
+        // IDN.toASCII with the default flags does not enforce this: it punycode-encodes such a
+        // label (for example a leading-hyphen "-tést" becomes "xn---tst-cpa") to a form that
+        // then satisfies the label regex, so the hyphen slips through on a non-ASCII label although
+        // the all-ASCII form is rejected. Keep the original here and let the label regex reject it
+        // (VALIDATOR-501).
+        if (hasLabelBoundaryHyphen(input)) {
+            return input;
         }
         try {
             final String ascii = IDN.toASCII(input);

--- a/src/test/java/org/apache/commons/validator/routines/DomainValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/DomainValidatorTest.java
@@ -47,7 +47,6 @@ import java.util.regex.Pattern;
 
 import org.apache.commons.validator.routines.DomainValidator.ArrayType;
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 /**
@@ -506,11 +505,15 @@ public class DomainValidatorTest {
     }
 
     @Test
-    @Disabled
     void testInvalidDomains501() {
-        // VALIDATOR-501
+        // VALIDATOR-501: a non-ASCII label starting or ending with a hyphen is punycode-encoded by
+        // IDN.toASCII to a form that passes the label regex, so it slipped through although the
+        // all-ASCII form ("-test.fr" / "test-.fr") is rejected in testInvalidDomains above.
         assertFalse(validator.isValid("-tést.fr"));
         assertFalse(validator.isValid("tést-.fr"));
+        assertFalse(validator.isValid("-é.fr"), "single non-ASCII label starting with a hyphen shouldn't validate");
+        // an interior hyphen on a non-ASCII label is still allowed
+        assertTrue(validator.isValid("a-é.fr"), "interior hyphen on a non-ASCII label should validate");
     }
 
     // Check if IDN.toASCII is broken or not


### PR DESCRIPTION
DomainValidator.isValid accepts a non-ASCII domain label that begins or ends with a hyphen: isValid("-tést.fr") and isValid("tést-.fr") both return true, though the all-ASCII forms "-test.fr" and "test-.fr" are correctly rejected. This is VALIDATOR-501, whose DomainValidatorTest.testInvalidDomains501 has been sitting @Disabled. The divergence is in the shared unicodeToASCII helper: for a label carrying a non-ASCII character it defers to IDN.toASCII, which with the default flags does not apply the LDH rule and punycode-encodes the boundary hyphen ("-tést" becomes "xn---tst-cpa"), so the converted label starts and ends alphanumeric, DOMAIN_LABEL_REGEX matches, and the hyphen the ASCII path would have caught slips through. UrlValidator.isValidAuthority and the EmailValidator domain check share unicodeToASCII, so they inherit the same hole.

The fix scans the original input before conversion and, when any label opens or closes with a hyphen, returns it unchanged so the label regex rejects it, matching the format-code-point guard added a few lines above. It splits on the four label separators from RFC 3490 section 3.1 and leaves an interior hyphen alone, so "a-é.fr" keeps validating while "-é.fr" does not. Keeping the check in the shared helper closes the gap for DomainValidator, UrlValidator and EmailValidator in one place rather than in each caller. I enabled testInvalidDomains501 and added the "-é.fr"/"a-é.fr" pair; the full suite stays green.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
