### PR TITLE
Reject trailing characters in strict date validation

### DIFF
--- a/src/main/java/org/apache/commons/validator/DateValidator.java
+++ b/src/main/java/org/apache/commons/validator/DateValidator.java
@@ -18,6 +18,7 @@ package org.apache.commons.validator;
 
 import java.text.DateFormat;
 import java.text.ParseException;
+import java.text.ParsePosition;
 import java.text.SimpleDateFormat;
 import java.util.Locale;
 
@@ -97,12 +98,11 @@ public class DateValidator {
         }
         final SimpleDateFormat formatter = new SimpleDateFormat(datePattern);
         formatter.setLenient(false);
-        try {
-            formatter.parse(value);
-        } catch (final ParseException e) {
-            return false;
-        }
-        if (strict && datePattern.length() != value.length()) {
+        final ParsePosition pos = new ParsePosition(0);
+        // parse(String, ParsePosition) stops at the first unparsable character instead of failing, so a strict
+        // match must also confirm the whole value was consumed; otherwise trailing text such as the 'f' in
+        // "11/11/199f" is dropped and the truncated date validates.
+        if (formatter.parse(value, pos) == null || strict && (pos.getIndex() < value.length() || datePattern.length() != value.length())) {
             return false;
         }
         return true;

--- a/src/main/java/org/apache/commons/validator/GenericTypeValidator.java
+++ b/src/main/java/org/apache/commons/validator/GenericTypeValidator.java
@@ -143,22 +143,18 @@ public class GenericTypeValidator implements Serializable {
      * @return The converted Date value.
      */
     public static Date formatDate(final String value, final String datePattern, final boolean strict) {
-        Date date = null;
         if (value == null || datePattern == null || datePattern.isEmpty()) {
             return null;
         }
-        try {
-            final SimpleDateFormat formatter = new SimpleDateFormat(datePattern);
-            formatter.setLenient(false);
-            date = formatter.parse(value);
-            if (strict && datePattern.length() != value.length()) {
-                date = null;
-            }
-        } catch (final ParseException e) {
-            // Bad date so return null
-            if (LOG.isDebugEnabled()) {
-                LOG.debug("Date parse failed value=[" + value + "], " + "pattern=[" + datePattern + "], " + "strict=[" + strict + "] " + e);
-            }
+        final SimpleDateFormat formatter = new SimpleDateFormat(datePattern);
+        formatter.setLenient(false);
+        final ParsePosition pos = new ParsePosition(0);
+        Date date = formatter.parse(value, pos);
+        // parse(String, ParsePosition) stops at the first unparsable character instead of failing, so a strict
+        // match must also confirm the whole value was consumed; otherwise trailing text such as the 'f' in
+        // "11/11/199f" is dropped and the truncated date validates.
+        if (date != null && strict && (pos.getIndex() < value.length() || datePattern.length() != value.length())) {
+            date = null;
         }
         return date;
     }

--- a/src/test/java/org/apache/commons/validator/GenericTypeValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/GenericTypeValidatorTest.java
@@ -134,6 +134,21 @@ class GenericTypeValidatorTest extends AbstractCommonTest {
     }
 
     /**
+     * Tests that strict {@link GenericTypeValidator#formatDate(String, String, boolean)} rejects a value with trailing characters instead of parsing only its
+     * leading portion.
+     */
+    @Test
+    void testFormatDateStrict() {
+        assertNotNull(GenericTypeValidator.formatDate("11/11/1999", "MM/dd/yyyy", true));
+        // The trailing 'f' used to be dropped, leaving the year parsed as 199 and the value reported as valid.
+        assertNull(GenericTypeValidator.formatDate("11/11/199f", "MM/dd/yyyy", true));
+        // An abbreviated field is still rejected in strict mode.
+        assertNull(GenericTypeValidator.formatDate("2/12/1999", "MM/dd/yyyy", true));
+        // Non-strict parsing stays lenient about the pattern length.
+        assertNotNull(GenericTypeValidator.formatDate("2/12/1999", "MM/dd/yyyy", false));
+    }
+
+    /**
      * Tests the byte validation.
      */
     @Test

--- a/src/test/java/org/apache/commons/validator/GenericValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/GenericValidatorTest.java
@@ -49,6 +49,14 @@ class GenericValidatorTest {
     }
 
     @Test
+    void testIsDate() {
+        assertTrue(GenericValidator.isDate("11/11/1999", "MM/dd/yyyy", true), "valid strict date");
+        // Strict validation used to accept a value with a trailing character by parsing only its leading portion.
+        assertFalse(GenericValidator.isDate("11/11/199f", "MM/dd/yyyy", true), "trailing character");
+        assertFalse(GenericValidator.isDate("2/12/1999", "MM/dd/yyyy", true), "abbreviated month");
+    }
+
+    @Test
     void testMinLength() {
 
         // Use 0 for line end length


### PR DESCRIPTION
Chasing how the `strict` flag is meant to enforce an exact match in the pattern-based date helpers, I found it rests entirely on `datePattern.length() != value.length()`. `SimpleDateFormat.parse(String)` stops at the first character it cannot read instead of failing, so a value whose trailing rubbish keeps the length equal to the pattern walks straight through: `formatDate("11/11/199f", "MM/dd/yyyy", true)` consumes only `11/11/199`, quietly reads the year as 199 and hands back a `Date`, and `GenericValidator.isDate` calls the same string valid. The truncated year in a debug trace is what gives it away. The same heuristic sits in `GenericTypeValidator.formatDate` and in the deprecated `DateValidator.isValid` that `GenericValidator.isDate` delegates to, so both accept the garbage.

Both methods now run the parse through a `ParsePosition` and, when `strict`, reject the value unless the parse reached the end of it, which is the full-consumption check `routines/AbstractFormatValidator.parse` already uses. The length comparison stays in place, so an abbreviated field like `2/12/1999` is still rejected and non-strict parsing keeps its current leniency. Left alone, any caller trusting the strict contract to screen malformed dates takes attacker-supplied trailing data and stores a different date from the one submitted.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
