### PR TITLE
Reject over-length codes in ISSNCheckDigit

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/ISSNCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/ISSNCheckDigit.java
@@ -52,6 +52,9 @@ public final class ISSNCheckDigit extends ModulusCheckDigit {
 
     private static final long serialVersionUID = 1L;
 
+    /** An ISSN is exactly eight characters: seven digits plus the check digit. */
+    private static final int ISSN_LEN = 8;
+
     /**
      * Singleton ISSN Check Digit instance.
      */
@@ -62,6 +65,23 @@ public final class ISSNCheckDigit extends ModulusCheckDigit {
      */
     public ISSNCheckDigit() {
         super(MODULUS_11);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>
+     * The {@code 9 - leftPos} weighting gives a ninth character a weight of zero, so an over-length code left the
+     * trailing characters unweighted and still passed the modulus test (for example every {@code 03178471} + digit
+     * validated). The length is checked here so only a genuine eight-character ISSN reaches the check digit test.
+     * </p>
+     */
+    @Override
+    public boolean isValid(final String code) {
+        if (code != null && code.length() != ISSN_LEN) {
+            return false;
+        }
+        return super.isValid(code);
     }
 
     @Override

--- a/src/test/java/org/apache/commons/validator/routines/checkdigit/ISSNCheckDigitTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/checkdigit/ISSNCheckDigitTest.java
@@ -16,7 +16,11 @@
  */
 package org.apache.commons.validator.routines.checkdigit;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * ISSN Check Digit Test.
@@ -36,6 +40,18 @@ class ISSNCheckDigitTest extends AbstractCheckDigitTest {
                 " 1365201X", "1365201X ", " 1365201X ", };
         missingMessage = "Code is missing";
         zeroSum = "00000000";
+    }
+
+    /**
+     * An ISSN is exactly eight characters. Appending a character to a valid ISSN pushes the extra character to a
+     * position weighted zero (the routine weights each position by {@code 9 - leftPos}), so the modulus was unaffected
+     * and every over-length code validated. The first ten append a digit to a valid ISSN; the last is longer still.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = { "031784710", "031784711", "031784712", "031784713", "031784714", "031784715", "031784716", "031784717", "031784718", "031784719",
+            "0317847100", })
+    void testOverLengthRejected(final String code) {
+        assertFalse(routine.isValid(code), "Should fail (not eight characters): " + code);
     }
 
 }


### PR DESCRIPTION
Noticed while exercising the check digit routines directly rather than through their wrapper validators.

1. `ISSNCheckDigit.ISSN_CHECK_DIGIT.isValid` is a public entry point and `ModulusCheckDigit` never checks the code length, so an over-length string reaches the modulus test unchecked.
2. `weightedValue` weights each position by `9 - leftPos`, so a ninth character lands on weight zero and contributes nothing; appending any character to a valid numeric ISSN (`031784710`..`031784719`, `0317847100`) still returns true, though only the eight-character `03178471` is a real ISSN.
3. Guarded `isValid` to require the fixed eight-character length before the check digit test, the same shape as the existing `IBANCheckDigit` length guard; the `ISSNValidator`/`CodeValidator` path already enforces length, so valid input is unaffected.

Regression test `testOverLengthRejected` added, which fails on the current code and passes with the guard.