### PR TITLE
Reject over-length codes in ABA, CUSIP, ISBN-10 and EAN-13 check digits

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/ABANumberCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/ABANumberCheckDigit.java
@@ -55,10 +55,30 @@ public final class ABANumberCheckDigit extends ModulusCheckDigit {
     /** Weighting given to digits depending on their right position */
     private static final int[] POSITION_WEIGHT = {3, 1, 7};
 
+    /** An ABA number is exactly nine digits, the last being the check digit. */
+    private static final int ABAN_LEN = 9;
+
     /**
      * Constructs a modulus 10 Check Digit routine for ABA Numbers.
      */
     public ABANumberCheckDigit() {
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>
+     * The weight is taken from {@code rightPos}, which does not change when a character is prepended, so
+     * {@code ModulusCheckDigit} would accept an over-length code whose leading digit lands on a no-op weight (for
+     * example {@code 0123456780}). The nine-character length is checked here before the check digit test.
+     * </p>
+     */
+    @Override
+    public boolean isValid(final String code) {
+        if (code != null && code.length() != ABAN_LEN) {
+            return false;
+        }
+        return super.isValid(code);
     }
 
     /**

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/CUSIPCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/CUSIPCheckDigit.java
@@ -47,10 +47,30 @@ public final class CUSIPCheckDigit extends ModulusCheckDigit {
     /** Weighting given to digits depending on their right position */
     private static final int[] POSITION_WEIGHT = { 2, 1 };
 
+    /** A CUSIP is exactly nine characters, the last being the check digit. */
+    private static final int CUSIP_LEN = 9;
+
     /**
      * Constructs a CUSIP Identifier Check Digit routine.
      */
     public CUSIPCheckDigit() {
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>
+     * The weight is taken from {@code rightPos}, which does not change when a character is prepended, so
+     * {@code ModulusCheckDigit} would accept an over-length code whose leading character lands on a no-op weight (for
+     * example {@code 0037833100}). The nine-character length is checked here before the check digit test.
+     * </p>
+     */
+    @Override
+    public boolean isValid(final String code) {
+        if (code != null && code.length() != CUSIP_LEN) {
+            return false;
+        }
+        return super.isValid(code);
     }
 
     /**

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/EAN13CheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/EAN13CheckDigit.java
@@ -53,10 +53,31 @@ public final class EAN13CheckDigit extends ModulusCheckDigit {
     /** Weighting given to digits depending on their right position */
     private static final int[] POSITION_WEIGHT = {3, 1};
 
+    /** An EAN-13 (and ISBN-13) code is exactly thirteen digits, the last being the check digit. */
+    private static final int EAN13_LEN = 13;
+
     /**
      * Constructs a modulus 10 Check Digit routine for EAN/UPC.
      */
     public EAN13CheckDigit() {
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>
+     * The weight is taken from {@code rightPos}, which does not change when a character is prepended, so
+     * {@code ModulusCheckDigit} would accept an over-length code whose leading digit lands on a no-op weight (for
+     * example a valid code with a {@code 0} prepended). The thirteen-character length is checked here before the check
+     * digit test.
+     * </p>
+     */
+    @Override
+    public boolean isValid(final String code) {
+        if (code != null && code.length() != EAN13_LEN) {
+            return false;
+        }
+        return super.isValid(code);
     }
 
     /**

--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/ISBN10CheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/ISBN10CheckDigit.java
@@ -49,11 +49,32 @@ public final class ISBN10CheckDigit extends ModulusCheckDigit {
      */
     public static final CheckDigit ISBN10_CHECK_DIGIT = new ISBN10CheckDigit();
 
+    /** An ISBN-10 is exactly ten characters, the last being the check digit. */
+    private static final int ISBN10_LEN = 10;
+
     /**
      * Constructs a modulus 11 Check Digit routine for ISBN-10.
      */
     public ISBN10CheckDigit() {
         super(MODULUS_11);
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * <p>
+     * The weight is {@code rightPos}, which does not change when a character is prepended, and modulus 11 makes the
+     * leading position weight a multiple of the modulus, so {@code ModulusCheckDigit} would accept an over-length code
+     * with any prepended digit (for example {@code 51930110995}). The ten-character length is checked here before the
+     * check digit test.
+     * </p>
+     */
+    @Override
+    public boolean isValid(final String code) {
+        if (code != null && code.length() != ISBN10_LEN) {
+            return false;
+        }
+        return super.isValid(code);
     }
 
     /**

--- a/src/test/java/org/apache/commons/validator/routines/checkdigit/ABANumberCheckDigitTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/checkdigit/ABANumberCheckDigitTest.java
@@ -16,7 +16,11 @@
  */
 package org.apache.commons.validator.routines.checkdigit;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * ABA Number Check Digit Test.
@@ -30,6 +34,16 @@ class ABANumberCheckDigitTest extends AbstractCheckDigitTest {
     protected void setUp() {
         routine = ABANumberCheckDigit.ABAN_CHECK_DIGIT;
         valid = new String[] { "123456780", "123123123", "011000015", "111000038", "231381116", "121181976" };
+    }
+
+    /**
+     * An ABA number is exactly nine digits. Prepending a zero to a valid code lands on a position weighted zero, so the
+     * modulus was unaffected and the over-length code validated.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = { "0123456780", "00123456780", "0011000015" })
+    void testOverLengthRejected(final String code) {
+        assertFalse(routine.isValid(code), "Should fail (not nine digits): " + code);
     }
 
 }

--- a/src/test/java/org/apache/commons/validator/routines/checkdigit/CUSIPCheckDigitTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/checkdigit/CUSIPCheckDigitTest.java
@@ -23,6 +23,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * CUSIP Check Digit Test.
@@ -62,5 +63,15 @@ class CUSIPCheckDigitTest extends AbstractCheckDigitTest {
     @MethodSource("org.apache.commons.validator.routines.checkdigit.CUSIPCheckDigitTest#cloneValid")
     void testValidator336ValidCheckDigits(final String validCheckDigit) {
         assertTrue(routine.isValid(validCheckDigit), "Should fail: " + validCheckDigit);
+    }
+
+    /**
+     * A CUSIP is exactly nine characters. Prepending a zero to a valid code lands on a position weighted zero, so the
+     * modulus was unaffected and the over-length code validated.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = { "0037833100", "0931142103" })
+    void testOverLengthRejected(final String code) {
+        assertFalse(routine.isValid(code), "Should fail (not nine characters): " + code);
     }
 }

--- a/src/test/java/org/apache/commons/validator/routines/checkdigit/EAN13CheckDigitTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/checkdigit/EAN13CheckDigitTest.java
@@ -16,7 +16,11 @@
  */
 package org.apache.commons.validator.routines.checkdigit;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * EAN-13 Check Digit Test.
@@ -30,6 +34,16 @@ class EAN13CheckDigitTest extends AbstractCheckDigitTest {
     protected void setUp() {
         routine = EAN13CheckDigit.EAN13_CHECK_DIGIT;
         valid = new String[] { "9780072129519", "9780764558313", "4025515373438", "0095673400332" };
+    }
+
+    /**
+     * An EAN-13 code is exactly thirteen digits. Prepending a zero to a valid code lands on a position weighted by the
+     * routine so the leading digit contributes nothing, leaving the modulus unchanged and the over-length code valid.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = { "09780072129519", "00095673400332" })
+    void testOverLengthRejected(final String code) {
+        assertFalse(routine.isValid(code), "Should fail (not thirteen digits): " + code);
     }
 
 }

--- a/src/test/java/org/apache/commons/validator/routines/checkdigit/ISBN10CheckDigitTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/checkdigit/ISBN10CheckDigitTest.java
@@ -16,7 +16,11 @@
  */
 package org.apache.commons.validator.routines.checkdigit;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 
 /**
  * ISBN-10 Check Digit Test.
@@ -30,6 +34,17 @@ class ISBN10CheckDigitTest extends AbstractCheckDigitTest {
     protected void setUp() {
         routine = ISBN10CheckDigit.ISBN10_CHECK_DIGIT;
         valid = new String[] { "1930110995", "020163385X", "1932394354", "1590596277" };
+    }
+
+    /**
+     * An ISBN-10 is exactly ten characters. Because the routine is modulus 11 and weights by position from the right,
+     * the prepended digit lands on a weight that is a multiple of the modulus, so any over-length code with a leading
+     * digit validated.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = { "01930110995", "51930110995", "91930110995", "0020163385X" })
+    void testOverLengthRejected(final String code) {
+        assertFalse(routine.isValid(code), "Should fail (not ten characters): " + code);
     }
 
 }


### PR DESCRIPTION
Following up on #426, I went back through the rest of the check digit package looking for the same length hole. ModulusCheckDigit.isValid never checks the code length, and calculateModulus weights each character by rightPos = length minus index, which does not move when a character is prepended. So the routines that weight purely on rightPos accept an over-length code whenever the prepended character lands on a no-op weight: ABANumberCheckDigit validates 0123456780, CUSIPCheckDigit validates 0037833100, and EAN13CheckDigit validates a genuine thirteen digit code carrying a leading zero. ISBN10CheckDigit is worse because it is modulus 11, so the leading position weight is a multiple of the modulus and any prepended digit is swallowed, for example 51930110995. Each of these singletons is a public entry point reachable without its wrapper validator, so a caller running a code straight through the routine treats the padded string as genuine.

The guard sits in each routine's isValid and rejects a code whose length is not the fixed length before the check digit test, the same shape merged for ISSNCheckDigit and the length guard already present in IBANCheckDigit. Keeping it in the routine covers the direct callers, not just the wrapper paths that already enforce length through CodeValidator. I deliberately left ISINCheckDigit alone since it is length agnostic by design (the 3133EHHF3 fixture from VALIDATOR-422 is a valid check digit on a non ISIN length), and SedolCheckDigit already caps its length; CAS, EC, Verhoeff and Luhn are either regex length checked or variable length and so are not affected. Each routine gets a regression test that fails before the guard and passes with it.
