### PR TITLE
Require the IPv6: tag for bracketed IPv6 email literals

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/EmailValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/EmailValidator.java
@@ -43,6 +43,8 @@ public class EmailValidator implements Serializable {
 
     private static final String EMAIL_REGEX = "^(.+)@(\\S+)$";
     private static final String IP_DOMAIN_REGEX = "^\\[(.*)\\]$";
+    // RFC 5321 section 4.1.3: an IPv6 address literal is prefixed with this tag, an IPv4 literal is not.
+    private static final String IPV6_TAG = "IPv6:";
     private static final String USER_REGEX = "^" + WORD + "(\\." + WORD + ")*$";
 
     private static final Pattern EMAIL_PATTERN = Pattern.compile(EMAIL_REGEX);
@@ -195,9 +197,14 @@ public class EmailValidator implements Serializable {
         final Matcher ipDomainMatcher = IP_DOMAIN_PATTERN.matcher(domain);
 
         if (ipDomainMatcher.matches()) {
-            final InetAddressValidator inetAddressValidator =
-                    InetAddressValidator.getInstance();
-            return inetAddressValidator.isValid(ipDomainMatcher.group(1));
+            final InetAddressValidator inetAddressValidator = InetAddressValidator.getInstance();
+            final String ipLiteral = ipDomainMatcher.group(1);
+            // An IPv6 address literal carries the "IPv6:" tag and an IPv4 literal is untagged (RFC 5321). The tag
+            // is ABNF-literal text, so match it case insensitively rather than accepting a bare IPv6 address.
+            if (ipLiteral.regionMatches(true, 0, IPV6_TAG, 0, IPV6_TAG.length())) {
+                return inetAddressValidator.isValidInet6Address(ipLiteral.substring(IPV6_TAG.length()));
+            }
+            return inetAddressValidator.isValidInet4Address(ipLiteral);
         }
         // Domain is symbolic name
         if (allowTld) {

--- a/src/main/java/org/apache/commons/validator/routines/EmailValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/EmailValidator.java
@@ -42,7 +42,10 @@ public class EmailValidator implements Serializable {
     private static final String WORD = "((" + VALID_CHARS + "|')+|" + QUOTED_USER + ")";
 
     private static final String EMAIL_REGEX = "^(.+)@(\\S+)$";
-    // RFC 5321 section 4.1.3: an IPv6 address literal carries the "IPv6:" tag (case-insensitive), an IPv4 literal is untagged.
+
+    /**
+     * RFC 5321 section 4.1.3: an IPv6 address literal carries the "IPv6:" tag (case-insensitive), an IPv4 literal is untagged.
+     */
     private static final String IP_DOMAIN_REGEX = "^\\[((?i)IPv6:)?(.*)\\]$";
     private static final String USER_REGEX = "^" + WORD + "(\\." + WORD + ")*$";
 

--- a/src/main/java/org/apache/commons/validator/routines/EmailValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/EmailValidator.java
@@ -42,9 +42,8 @@ public class EmailValidator implements Serializable {
     private static final String WORD = "((" + VALID_CHARS + "|')+|" + QUOTED_USER + ")";
 
     private static final String EMAIL_REGEX = "^(.+)@(\\S+)$";
-    private static final String IP_DOMAIN_REGEX = "^\\[(.*)\\]$";
-    // RFC 5321 section 4.1.3: an IPv6 address literal is prefixed with this tag, an IPv4 literal is not.
-    private static final String IPV6_TAG = "IPv6:";
+    // RFC 5321 section 4.1.3: an IPv6 address literal carries the "IPv6:" tag (case-insensitive), an IPv4 literal is untagged.
+    private static final String IP_DOMAIN_REGEX = "^\\[((?i)IPv6:)?(.*)\\]$";
     private static final String USER_REGEX = "^" + WORD + "(\\." + WORD + ")*$";
 
     private static final Pattern EMAIL_PATTERN = Pattern.compile(EMAIL_REGEX);
@@ -198,13 +197,10 @@ public class EmailValidator implements Serializable {
 
         if (ipDomainMatcher.matches()) {
             final InetAddressValidator inetAddressValidator = InetAddressValidator.getInstance();
-            final String ipLiteral = ipDomainMatcher.group(1);
-            // An IPv6 address literal carries the "IPv6:" tag and an IPv4 literal is untagged (RFC 5321). The tag
-            // is ABNF-literal text, so match it case insensitively rather than accepting a bare IPv6 address.
-            if (ipLiteral.regionMatches(true, 0, IPV6_TAG, 0, IPV6_TAG.length())) {
-                return inetAddressValidator.isValidInet6Address(ipLiteral.substring(IPV6_TAG.length()));
+            if (ipDomainMatcher.group(1) != null) {
+                return inetAddressValidator.isValidInet6Address(ipDomainMatcher.group(2));
             }
-            return inetAddressValidator.isValidInet4Address(ipLiteral);
+            return inetAddressValidator.isValidInet4Address(ipDomainMatcher.group(2));
         }
         // Domain is symbolic name
         if (allowTld) {

--- a/src/test/java/org/apache/commons/validator/routines/EmailValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/EmailValidatorTest.java
@@ -454,6 +454,23 @@ public class EmailValidatorTest {
     }
 
     /**
+     * Tests IPv6 address literals in the domain, which RFC 5321 section 4.1.3 tags with "IPv6:".
+     */
+    @Test
+    void testEmailWithIpv6AddressLiteral() {
+        // Tagged IPv6 literals are accepted; the tag is ABNF-literal text so it is case insensitive.
+        assertTrue(validator.isValid("someone@[IPv6:2001:db8::1]"));
+        assertTrue(validator.isValid("someone@[IPv6:::1]"));
+        assertTrue(validator.isValid("someone@[ipv6:fe80::1]"));
+        // A bare IPv6 literal without the tag is not a valid address literal.
+        assertFalse(validator.isValid("someone@[2001:db8::1]"));
+        assertFalse(validator.isValid("someone@[::1]"));
+        // The tag is IPv6 only; an IPv4 literal stays untagged.
+        assertTrue(validator.isValid("someone@[216.109.118.76]"));
+        assertFalse(validator.isValid("someone@[IPv6:216.109.118.76]"));
+    }
+
+    /**
      * VALIDATOR-296 - A / or a ! is valid in the user part, but not in the domain part
      */
     @Test


### PR DESCRIPTION
- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.

`EmailValidator.isValidDomain` hands the contents of a bracketed host to `InetAddressValidator.isValid`, which accepts an IPv4 or an IPv6 address without distinguishing them. RFC 5321 section 4.1.3 tags an IPv6 address literal with `IPv6:` and leaves an IPv4 literal untagged, so the current code is wrong at both ends: it accepts a bare `user@[::1]`, which no conformant parser should, and rejects the correctly tagged `user@[IPv6:::1]` because the `IPv6:` prefix reaches `InetAddressValidator` as part of the address and the parse fails. I came across it while checking why a valid IPv6 literal was being turned away when the malformed bare form validated.

The fix matches the `IPv6:` tag on the bracket contents, case insensitively since it is ABNF-literal text, and validates the remainder as IPv6; an untagged literal is validated as IPv4 only. Keeping the split in `isValidDomain` leaves the IPv4-versus-IPv6 rule in the one place that parses the bracketed host, and the deprecated `validator.EmailValidator` inherits it because its `isValid` delegates here. Left unfixed, an allow-list built on this treats a bare loopback or link-local literal that no conformant MTA routes as valid while refusing the RFC form.
