### PR TITLE
Reject nameprep-stripped code points in unicodeToASCII

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/DomainValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/DomainValidator.java
@@ -1966,6 +1966,19 @@ public class DomainValidator implements Serializable {
         return true;
     }
 
+    /*
+     * Tests whether the code point is one that IDNA nameprep (RFC 3454 Table B.1, "commonly mapped to
+     * nothing") deletes but that is not a Unicode FORMAT character, so the FORMAT check in
+     * unicodeToASCII does not catch it: the combining grapheme joiner, the Mongolian TODO soft hyphen
+     * and free variation selectors, and the variation selectors.
+     */
+    private static boolean isNameprepMappedToNothing(final int codePoint) {
+        return codePoint == '\u034F' // COMBINING GRAPHEME JOINER
+                || codePoint == '\u1806' // MONGOLIAN TODO SOFT HYPHEN
+                || codePoint >= '\u180B' && codePoint <= '\u180D' // MONGOLIAN FREE VARIATION SELECTOR ONE..THREE
+                || codePoint >= '\uFE00' && codePoint <= '\uFE0F'; // VARIATION SELECTOR-1..16
+    }
+
     /**
      * Converts potentially Unicode input to punycode. If conversion fails, returns the original input.
      *
@@ -1977,13 +1990,16 @@ public class DomainValidator implements Serializable {
         if (isOnlyASCII(input)) { // skip possibly expensive processing
             return input;
         }
-        // IDN.toASCII silently drops default-ignorable and format code points (soft hyphen,
-        // zero-width spaces, the byte order mark, ...) during nameprep, so a host carrying one
-        // would convert to a clean label and validate. Those code points are not legal in a host
-        // name, so keep the original here and let the label regex reject it.
+        // IDN.toASCII silently drops the code points that nameprep (RFC 3454 Table B.1) maps to
+        // nothing - the soft hyphen, zero-width spaces, the byte order mark, the combining grapheme
+        // joiner, the Mongolian and variation selectors and so on - so a host carrying one would
+        // convert to a clean label and validate as a different host. Most are Unicode FORMAT
+        // characters, but the combining grapheme joiner, the Mongolian selectors and the variation
+        // selectors are not, so the FORMAT check alone lets them through. Reject both here and let
+        // the label regex reject anything else.
         for (int i = 0; i < input.length();) {
             final int codePoint = input.codePointAt(i);
-            if (Character.getType(codePoint) == Character.FORMAT) {
+            if (Character.getType(codePoint) == Character.FORMAT || isNameprepMappedToNothing(codePoint)) {
                 return input;
             }
             i += Character.charCount(codePoint);

--- a/src/test/java/org/apache/commons/validator/routines/DomainValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/DomainValidatorTest.java
@@ -471,6 +471,18 @@ public class DomainValidatorTest {
     }
 
     @Test
+    void testIDNMappedToNothing() {
+        // IDN.toASCII also strips the code points that nameprep maps to nothing but that are not
+        // Unicode FORMAT characters, so the format-code-point guard alone would let them collapse a
+        // host to a clean label. They must be rejected too.
+        assertFalse(validator.isValid("exa\u034Fmple.com"), "combining grapheme joiner shouldn't validate");
+        assertFalse(validator.isValid("exa\uFE0Fmple.com"), "variation selector shouldn't validate");
+        assertFalse(validator.isValid("exa\u1806mple.com"), "Mongolian TODO soft hyphen shouldn't validate");
+        assertFalse(validator.isValid("exa\u180Bmple.com"), "Mongolian free variation selector shouldn't validate");
+        assertTrue(validator.isValid("www.b\u00fccher.ch"), "b\u00fccher.ch should still validate");
+    }
+
+    @Test
     void testIDNJava6OrLater() {
         // xn--d1abbgf6aiiy.xn--p1ai http://президент.рф
         assertTrue(validator.isValid("www.b\u00fccher.ch"), "b\u00fccher.ch should validate");

--- a/src/test/java/org/apache/commons/validator/routines/DomainValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/DomainValidatorTest.java
@@ -465,6 +465,7 @@ public class DomainValidatorTest {
         // Those code points are not legal in a host name and must be rejected.
         assertFalse(validator.isValid("exa\u00ADmple.com"), "soft hyphen shouldn't validate");
         assertFalse(validator.isValid("exa\u200Bmple.com"), "zero-width space shouldn't validate");
+        assertFalse(validator.isValid("exa\u200Cmple.com"), "zero-width non-joiner shouldn't validate");
         assertFalse(validator.isValid("exa\u200Dmple.com"), "zero-width joiner shouldn't validate");
         assertFalse(validator.isValid("\uFEFFexample.com"), "byte order mark shouldn't validate");
         assertTrue(validator.isValid("www.b\u00fccher.ch"), "b\u00fccher.ch should still validate");


### PR DESCRIPTION
unicodeToASCII already returns the host unconverted when it carries a Unicode FORMAT code point, because IDN.toASCII deletes those during nameprep and the label would otherwise validate as a clean string. Walking the nameprep mapping showed the FORMAT category is only part of RFC 3454 Table B.1 ("commonly mapped to nothing"): the combining grapheme joiner U+034F, the Mongolian TODO soft hyphen and free variation selectors U+1806 and U+180B..U+180D, and the variation selectors U+FE00..U+FE0F are stripped as well but report as Mn/Pd, so the getType check waves them through. isValid("exa͏mple.com"), plus the variation-selector and Mongolian forms, convert to example.com and return true, so a byte-distinct host validates as example.com and EmailValidator.isValidDomain and UrlValidator.isValidAuthority inherit the hole; left alone it is an invisible-character homograph and an allow-list poisoning vector.

The guard now rejects those non-FORMAT code points beside the existing FORMAT check, so the label regex sees the original invisible character and fails it. Keeping it inside unicodeToASCII closes the domain, email and URL callers together rather than each re-testing for stripped code points, and legitimate IDN letters (bücher.ch, президент.рф) and the hangul fillers that punycode to a real label are untouched. testIDNMappedToNothing covers the four representative code points; it fails on master and passes with the guard.
