### PR TITLE
Drop the symbol separator in the currency and percent re-parse

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/BigDecimalValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/BigDecimalValidator.java
@@ -89,6 +89,39 @@ public class BigDecimalValidator extends AbstractNumberValidator {
     }
 
     /**
+     * Tests whether the character at the given position of a pattern sits next to the given symbol.
+     *
+     * @param pattern The pattern being stripped of the symbol.
+     * @param index   The position to test.
+     * @param symbol  The symbol being removed.
+     * @return {@code true} if the character borders the symbol.
+     */
+    private static boolean isNextToSymbol(final String pattern, final int index, final char symbol) {
+        return (index > 0 && pattern.charAt(index - 1) == symbol)
+                || (index + 1 < pattern.length() && pattern.charAt(index + 1) == symbol);
+    }
+
+    /**
+     * Removes the given symbol, and any space characters adjacent to it, from a {@link DecimalFormat} pattern. A locale that suffixes the symbol usually
+     * separates it from the number with a (non-breaking) space; that space belongs to the symbol, so removing only the symbol would leave the separator
+     * mandatory.
+     *
+     * @param pattern The pattern to remove the symbol from.
+     * @param symbol  The symbol to remove.
+     * @return The pattern without the symbol and its separator.
+     */
+    static String removeSymbol(final String pattern, final char symbol) {
+        final StringBuilder buffer = new StringBuilder(pattern.length());
+        for (int i = 0; i < pattern.length(); i++) {
+            final char chr = pattern.charAt(i);
+            if (chr != symbol && !(Character.isSpaceChar(chr) && isNextToSymbol(pattern, i, symbol))) {
+                buffer.append(chr);
+            }
+        }
+        return buffer.toString();
+    }
+
+    /**
      * Constructs a <em>strict</em> instance.
      */
     public BigDecimalValidator() {

--- a/src/main/java/org/apache/commons/validator/routines/CurrencyValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/CurrencyValidator.java
@@ -60,6 +60,18 @@ public class CurrencyValidator extends BigDecimalValidator {
     }
 
     /**
+     * Tests whether the character at the given position of a pattern sits next to the currency symbol.
+     *
+     * @param pattern The pattern being stripped of its currency symbol.
+     * @param index The position to test.
+     * @return {@code true} if the character borders the currency symbol.
+     */
+    private static boolean isNextToSymbol(final String pattern, final int index) {
+        return index > 0 && pattern.charAt(index - 1) == CURRENCY_SYMBOL
+                || index + 1 < pattern.length() && pattern.charAt(index + 1) == CURRENCY_SYMBOL;
+    }
+
+    /**
      * Constructs a <em>strict</em> instance.
      */
     public CurrencyValidator() {
@@ -106,8 +118,11 @@ public class CurrencyValidator extends BigDecimalValidator {
         if (pattern.indexOf(CURRENCY_SYMBOL) >= 0) {
             final StringBuilder buffer = new StringBuilder(pattern.length());
             for (int i = 0; i < pattern.length(); i++) {
-                if (pattern.charAt(i) != CURRENCY_SYMBOL) {
-                    buffer.append(pattern.charAt(i));
+                final char chr = pattern.charAt(i);
+                // A locale that suffixes the symbol usually separates it from the number with a (non-breaking)
+                // space. That space belongs to the symbol, so dropping only the symbol would leave it mandatory.
+                if (chr != CURRENCY_SYMBOL && !(Character.isSpaceChar(chr) && isNextToSymbol(pattern, i))) {
+                    buffer.append(chr);
                 }
             }
             decimalFormat.applyPattern(buffer.toString());

--- a/src/main/java/org/apache/commons/validator/routines/CurrencyValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/CurrencyValidator.java
@@ -60,18 +60,6 @@ public class CurrencyValidator extends BigDecimalValidator {
     }
 
     /**
-     * Tests whether the character at the given position of a pattern sits next to the currency symbol.
-     *
-     * @param pattern The pattern being stripped of its currency symbol.
-     * @param index The position to test.
-     * @return {@code true} if the character borders the currency symbol.
-     */
-    private static boolean isNextToSymbol(final String pattern, final int index) {
-        return index > 0 && pattern.charAt(index - 1) == CURRENCY_SYMBOL
-                || index + 1 < pattern.length() && pattern.charAt(index + 1) == CURRENCY_SYMBOL;
-    }
-
-    /**
      * Constructs a <em>strict</em> instance.
      */
     public CurrencyValidator() {
@@ -112,20 +100,11 @@ public class CurrencyValidator extends BigDecimalValidator {
             return parsedValue;
         }
 
-        // Re-parse using a pattern without the currency symbol
+        // Re-parse using a pattern without the currency symbol and its separator
         final DecimalFormat decimalFormat = (DecimalFormat) formatter;
         final String pattern = decimalFormat.toPattern();
         if (pattern.indexOf(CURRENCY_SYMBOL) >= 0) {
-            final StringBuilder buffer = new StringBuilder(pattern.length());
-            for (int i = 0; i < pattern.length(); i++) {
-                final char chr = pattern.charAt(i);
-                // A locale that suffixes the symbol usually separates it from the number with a (non-breaking)
-                // space. That space belongs to the symbol, so dropping only the symbol would leave it mandatory.
-                if (chr != CURRENCY_SYMBOL && !(Character.isSpaceChar(chr) && isNextToSymbol(pattern, i))) {
-                    buffer.append(chr);
-                }
-            }
-            decimalFormat.applyPattern(buffer.toString());
+            decimalFormat.applyPattern(removeSymbol(pattern, CURRENCY_SYMBOL));
             parsedValue = super.parse(value, decimalFormat);
         }
         return parsedValue;

--- a/src/main/java/org/apache/commons/validator/routines/PercentValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/PercentValidator.java
@@ -65,6 +65,18 @@ public class PercentValidator extends BigDecimalValidator {
     }
 
     /**
+     * Tests whether the character at the given position of a pattern sits next to the percent symbol.
+     *
+     * @param pattern The pattern being stripped of its percent symbol.
+     * @param index The position to test.
+     * @return {@code true} if the character borders the percent symbol.
+     */
+    private static boolean isNextToSymbol(final String pattern, final int index) {
+        return index > 0 && pattern.charAt(index - 1) == PERCENT_SYMBOL
+                || index + 1 < pattern.length() && pattern.charAt(index + 1) == PERCENT_SYMBOL;
+    }
+
+    /**
      * Constructs a <em>strict</em> instance.
      */
     public PercentValidator() {
@@ -109,8 +121,11 @@ public class PercentValidator extends BigDecimalValidator {
         if (pattern.indexOf(PERCENT_SYMBOL) >= 0) {
             final StringBuilder buffer = new StringBuilder(pattern.length());
             for (int i = 0; i < pattern.length(); i++) {
-                if (pattern.charAt(i) != PERCENT_SYMBOL) {
-                    buffer.append(pattern.charAt(i));
+                final char chr = pattern.charAt(i);
+                // A locale that suffixes the symbol usually separates it from the number with a (non-breaking)
+                // space. That space belongs to the symbol, so dropping only the symbol would leave it mandatory.
+                if (chr != PERCENT_SYMBOL && !(Character.isSpaceChar(chr) && isNextToSymbol(pattern, i))) {
+                    buffer.append(chr);
                 }
             }
             decimalFormat.applyPattern(buffer.toString());

--- a/src/main/java/org/apache/commons/validator/routines/PercentValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/PercentValidator.java
@@ -65,18 +65,6 @@ public class PercentValidator extends BigDecimalValidator {
     }
 
     /**
-     * Tests whether the character at the given position of a pattern sits next to the percent symbol.
-     *
-     * @param pattern The pattern being stripped of its percent symbol.
-     * @param index The position to test.
-     * @return {@code true} if the character borders the percent symbol.
-     */
-    private static boolean isNextToSymbol(final String pattern, final int index) {
-        return index > 0 && pattern.charAt(index - 1) == PERCENT_SYMBOL
-                || index + 1 < pattern.length() && pattern.charAt(index + 1) == PERCENT_SYMBOL;
-    }
-
-    /**
      * Constructs a <em>strict</em> instance.
      */
     public PercentValidator() {
@@ -115,20 +103,11 @@ public class PercentValidator extends BigDecimalValidator {
             return parsedValue;
         }
 
-        // Re-parse using a pattern without the percent symbol
+        // Re-parse using a pattern without the percent symbol and its separator
         final DecimalFormat decimalFormat = (DecimalFormat) formatter;
         final String pattern = decimalFormat.toPattern();
         if (pattern.indexOf(PERCENT_SYMBOL) >= 0) {
-            final StringBuilder buffer = new StringBuilder(pattern.length());
-            for (int i = 0; i < pattern.length(); i++) {
-                final char chr = pattern.charAt(i);
-                // A locale that suffixes the symbol usually separates it from the number with a (non-breaking)
-                // space. That space belongs to the symbol, so dropping only the symbol would leave it mandatory.
-                if (chr != PERCENT_SYMBOL && !(Character.isSpaceChar(chr) && isNextToSymbol(pattern, i))) {
-                    buffer.append(chr);
-                }
-            }
-            decimalFormat.applyPattern(buffer.toString());
+            decimalFormat.applyPattern(removeSymbol(pattern, PERCENT_SYMBOL));
             parsedValue = (BigDecimal) super.parse(value, decimalFormat);
 
             // If parsed OK, divide by 100 to get percent

--- a/src/test/java/org/apache/commons/validator/routines/CurrencyValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/CurrencyValidatorTest.java
@@ -20,15 +20,20 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.text.DecimalFormat;
 import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
 import java.util.Locale;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junitpioneer.jupiter.DefaultLocale;
 
 /**
@@ -43,6 +48,15 @@ class CurrencyValidatorTest {
 
     private String usDollar;
     private String ukPound;
+
+    /**
+     * Locales whose currency format suffixes the symbol behind a space separator, covering different concrete symbols (&euro; and kr).
+     *
+     * @return the locales to test.
+     */
+    static Stream<Locale> suffixSymbolLocales() {
+        return Stream.of(Locale.GERMANY, Locale.FRANCE, Locale.forLanguageTag("sv-SE"));
+    }
 
     @BeforeEach
     protected void setUp() {
@@ -180,18 +194,44 @@ class CurrencyValidatorTest {
     }
 
     /**
-     * Test currency values with a pattern that suffixes the symbol, which locales such as de-DE separate from the number with a non-breaking space. The symbol
-     * is optional, so its separator has to be optional too.
+     * Test currency values against the JVM's own format for locales that suffix the symbol behind a space separator. The symbol is optional, so its separator
+     * has to be optional too. The pattern, separator and input are all derived from the locale data at run time, so the expectations hold on any JVM; on older
+     * JVMs whose locale data does not use a space separated suffix symbol the test is skipped.
+     */
+    @ParameterizedTest
+    @MethodSource("suffixSymbolLocales")
+    void testSuffixSymbolLocale(final Locale locale) {
+        final DecimalFormat format = (DecimalFormat) NumberFormat.getCurrencyInstance(locale);
+        final String pattern = format.toPattern();
+        final int symbolIndex = pattern.indexOf(CURRENCY_SYMBOL);
+        assumeTrue(symbolIndex > 0 && Character.isSpaceChar(pattern.charAt(symbolIndex - 1)),
+                () -> locale + " does not use a space separated suffix symbol: " + pattern);
+        final char separator = pattern.charAt(symbolIndex - 1);
+        final String symbol = format.getDecimalFormatSymbols().getCurrencySymbol();
+        final String withSymbol = format.format(1234.56);
+        assumeTrue(withSymbol.endsWith(separator + symbol), () -> locale + " does not format the symbol last: " + withSymbol);
+        final String noSymbol = withSymbol.substring(0, withSymbol.length() - symbol.length() - 1);
+
+        final BigDecimalValidator instance = CurrencyValidator.getInstance();
+        final BigDecimal expected = new BigDecimal("1234.56");
+        assertEquals(expected, instance.validate(withSymbol, locale), "symbol: " + locale);
+        assertEquals(expected, instance.validate(noSymbol, locale), "no symbol: " + locale);
+        assertNull(instance.validate(noSymbol + separator, locale), "separator without symbol: " + locale);
+    }
+
+    /**
+     * Test currency values with an explicit pattern that suffixes the symbol behind a non-breaking space, so the expectations are pinned independently of the
+     * JVM's locale data. The symbol is optional, so its separator has to be optional too.
      */
     @Test
     void testSuffixSymbolPattern() {
-        final BigDecimalValidator validator = CurrencyValidator.getInstance();
+        final BigDecimalValidator instance = CurrencyValidator.getInstance();
         final String pattern = "#,##0.00" + NON_BREAKING_SPACE + CURRENCY_SYMBOL;
         final BigDecimal expected = new BigDecimal("1234.56");
 
-        assertEquals(expected, validator.validate("1,234.56" + NON_BREAKING_SPACE + usDollar, pattern, Locale.US), "symbol");
-        assertEquals(expected, validator.validate("1,234.56", pattern, Locale.US), "no symbol");
-        assertNull(validator.validate("1,234.56" + NON_BREAKING_SPACE, pattern, Locale.US), "separator without symbol");
+        assertEquals(expected, instance.validate("1,234.56" + NON_BREAKING_SPACE + usDollar, pattern, Locale.US), "symbol");
+        assertEquals(expected, instance.validate("1,234.56", pattern, Locale.US), "no symbol");
+        assertNull(instance.validate("1,234.56" + NON_BREAKING_SPACE, pattern, Locale.US), "separator without symbol");
     }
 
     /**

--- a/src/test/java/org/apache/commons/validator/routines/CurrencyValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/CurrencyValidatorTest.java
@@ -38,6 +38,9 @@ class CurrencyValidatorTest {
 
     private static final char CURRENCY_SYMBOL = '\u00A4';
 
+    /** The character locales such as de-DE use between the number and a trailing currency symbol. */
+    private static final char NON_BREAKING_SPACE = '\u00A0';
+
     private String usDollar;
     private String ukPound;
 
@@ -174,6 +177,21 @@ class CurrencyValidatorTest {
         // invalid
         assertFalse(validator.isValid(usDollar + "1,234.567", pattern), "invalid symbol");
         assertFalse(validator.isValid(ukPound + "1,234.567", pattern, Locale.US), "invalid symbol");
+    }
+
+    /**
+     * Test currency values with a pattern that suffixes the symbol, which locales such as de-DE separate from the number with a non-breaking space. The symbol
+     * is optional, so its separator has to be optional too.
+     */
+    @Test
+    void testSuffixSymbolPattern() {
+        final BigDecimalValidator validator = CurrencyValidator.getInstance();
+        final String pattern = "#,##0.00" + NON_BREAKING_SPACE + CURRENCY_SYMBOL;
+        final BigDecimal expected = new BigDecimal("1234.56");
+
+        assertEquals(expected, validator.validate("1,234.56" + NON_BREAKING_SPACE + usDollar, pattern, Locale.US), "symbol");
+        assertEquals(expected, validator.validate("1,234.56", pattern, Locale.US), "no symbol");
+        assertNull(validator.validate("1,234.56" + NON_BREAKING_SPACE, pattern, Locale.US), "separator without symbol");
     }
 
     /**

--- a/src/test/java/org/apache/commons/validator/routines/CurrencyValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/CurrencyValidatorTest.java
@@ -196,7 +196,8 @@ class CurrencyValidatorTest {
     /**
      * Test currency values against the JVM's own format for locales that suffix the symbol behind a space separator. The symbol is optional, so its separator
      * has to be optional too. The pattern, separator and input are all derived from the locale data at run time, so the expectations hold on any JVM; on older
-     * JVMs whose locale data does not use a space separated suffix symbol the test is skipped.
+     * JVMs whose locale data does not use a space separated suffix symbol the test is skipped. A bare separator with no symbol is rejected when the separator is
+     * a non-breaking space, but accepted when the locale data separates with a plain space, because the validator trims the input before parsing.
      */
     @ParameterizedTest
     @MethodSource("suffixSymbolLocales")
@@ -216,7 +217,12 @@ class CurrencyValidatorTest {
         final BigDecimal expected = new BigDecimal("1234.56");
         assertEquals(expected, instance.validate(withSymbol, locale), "symbol: " + locale);
         assertEquals(expected, instance.validate(noSymbol, locale), "no symbol: " + locale);
-        assertNull(instance.validate(noSymbol + separator, locale), "separator without symbol: " + locale);
+        if (separator > ' ') {
+            assertNull(instance.validate(noSymbol + separator, locale), "separator without symbol: " + locale);
+        } else {
+            // The legacy (pre-CLDR) locale data separates with a plain space, which the validator trims off before parsing.
+            assertEquals(expected, instance.validate(noSymbol + separator, locale), "trimmed separator without symbol: " + locale);
+        }
     }
 
     /**

--- a/src/test/java/org/apache/commons/validator/routines/CurrencyValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/CurrencyValidatorTest.java
@@ -220,18 +220,23 @@ class CurrencyValidatorTest {
     }
 
     /**
-     * Test currency values with an explicit pattern that suffixes the symbol behind a non-breaking space, so the expectations are pinned independently of the
-     * JVM's locale data. The symbol is optional, so its separator has to be optional too.
+     * Test currency values with an explicit pattern that suffixes the symbol behind a non-breaking space, run against every available locale so every currency
+     * symbol the JVM knows is exercised. The inputs are formatted with each locale's own symbols, so the expectations do not depend on any particular locale's
+     * data. The symbol is optional, so its separator has to be optional too.
      */
-    @Test
-    void testSuffixSymbolPattern() {
+    @ParameterizedTest
+    @MethodSource("java.util.Locale#getAvailableLocales")
+    void testSuffixSymbolPattern(final Locale locale) {
         final BigDecimalValidator instance = CurrencyValidator.getInstance();
         final String pattern = "#,##0.00" + NON_BREAKING_SPACE + CURRENCY_SYMBOL;
         final BigDecimal expected = new BigDecimal("1234.56");
+        final DecimalFormatSymbols symbols = new DecimalFormatSymbols(locale);
+        final String withSymbol = new DecimalFormat(pattern, symbols).format(expected);
+        final String withoutSymbol = new DecimalFormat("#,##0.00", symbols).format(expected);
 
-        assertEquals(expected, instance.validate("1,234.56" + NON_BREAKING_SPACE + usDollar, pattern, Locale.US), "symbol");
-        assertEquals(expected, instance.validate("1,234.56", pattern, Locale.US), "no symbol");
-        assertNull(instance.validate("1,234.56" + NON_BREAKING_SPACE, pattern, Locale.US), "separator without symbol");
+        assertEquals(expected, instance.validate(withSymbol, pattern, locale), "symbol");
+        assertEquals(expected, instance.validate(withoutSymbol, pattern, locale), "no symbol");
+        assertNull(instance.validate(withoutSymbol + NON_BREAKING_SPACE, pattern, locale), "separator without symbol");
     }
 
     /**

--- a/src/test/java/org/apache/commons/validator/routines/PercentValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/PercentValidatorTest.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import java.math.BigDecimal;
 import java.math.BigInteger;
 import java.text.DecimalFormat;
+import java.text.DecimalFormatSymbols;
 import java.text.NumberFormat;
 import java.util.Locale;
 import java.util.stream.Stream;
@@ -147,18 +148,23 @@ class PercentValidatorTest {
     }
 
     /**
-     * Test percentage values with an explicit pattern that suffixes the symbol behind a non-breaking space, so the expectations are pinned independently of the
-     * JVM's locale data. The symbol is optional, so its separator has to be optional too.
+     * Test percentage values with an explicit pattern that suffixes the symbol behind a non-breaking space, run against every available locale so every percent
+     * symbol the JVM knows is exercised. The inputs are formatted with each locale's own symbols, so the expectations do not depend on any particular locale's
+     * data. The symbol is optional, so its separator has to be optional too.
      */
-    @Test
-    void testSuffixSymbolPattern() {
+    @ParameterizedTest
+    @MethodSource("java.util.Locale#getAvailableLocales")
+    void testSuffixSymbolPattern(final Locale locale) {
         final BigDecimalValidator instance = PercentValidator.getInstance();
         final String pattern = "#,##0" + NON_BREAKING_SPACE + PERCENT_SYMBOL;
         final BigDecimal expected = new BigDecimal("0.12");
+        final DecimalFormatSymbols symbols = new DecimalFormatSymbols(locale);
+        final String withSymbol = new DecimalFormat(pattern, symbols).format(expected);
+        final String withoutSymbol = new DecimalFormat("#,##0", symbols).format(12);
 
-        assertEquals(expected, instance.validate("12" + NON_BREAKING_SPACE + PERCENT_SYMBOL, pattern, Locale.US), "symbol");
-        assertEquals(expected, instance.validate("12", pattern, Locale.US), "no symbol");
-        assertNull(instance.validate("12" + NON_BREAKING_SPACE, pattern, Locale.US), "separator without symbol");
+        assertEquals(expected, instance.validate(withSymbol, pattern, locale), "symbol");
+        assertEquals(expected, instance.validate(withoutSymbol, pattern, locale), "no symbol");
+        assertNull(instance.validate(withoutSymbol + NON_BREAKING_SPACE, pattern, locale), "separator without symbol");
     }
 
     /**

--- a/src/test/java/org/apache/commons/validator/routines/PercentValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/PercentValidatorTest.java
@@ -124,7 +124,8 @@ class PercentValidatorTest {
     /**
      * Test percentage values against the JVM's own format for locales that suffix the symbol behind a space separator. The symbol is optional, so its separator
      * has to be optional too. The pattern, separator and input are all derived from the locale data at run time, so the expectations hold on any JVM; on older
-     * JVMs whose locale data does not use a space separated suffix symbol the test is skipped.
+     * JVMs whose locale data does not use a space separated suffix symbol the test is skipped. A bare separator with no symbol is rejected when the separator is
+     * a non-breaking space, but accepted when the locale data separates with a plain space, because the validator trims the input before parsing.
      */
     @ParameterizedTest
     @MethodSource("suffixSymbolLocales")
@@ -144,7 +145,12 @@ class PercentValidatorTest {
         final BigDecimal expected = new BigDecimal("0.12");
         assertEquals(expected, instance.validate(withSymbol, locale), "symbol: " + locale);
         assertEquals(expected, instance.validate(noSymbol, locale), "no symbol: " + locale);
-        assertNull(instance.validate(noSymbol + separator, locale), "separator without symbol: " + locale);
+        if (separator > ' ') {
+            assertNull(instance.validate(noSymbol + separator, locale), "separator without symbol: " + locale);
+        } else {
+            // The legacy (pre-CLDR) locale data separates with a plain space, which the validator trims off before parsing.
+            assertEquals(expected, instance.validate(noSymbol + separator, locale), "trimmed separator without symbol: " + locale);
+        }
     }
 
     /**

--- a/src/test/java/org/apache/commons/validator/routines/PercentValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/PercentValidatorTest.java
@@ -20,14 +20,20 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
 import java.math.BigDecimal;
 import java.math.BigInteger;
+import java.text.DecimalFormat;
+import java.text.NumberFormat;
 import java.util.Locale;
+import java.util.stream.Stream;
 
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.junitpioneer.jupiter.DefaultLocale;
 
 /**
@@ -42,6 +48,15 @@ class PercentValidatorTest {
 
     protected PercentValidator validator;
     private Locale originalLocale;
+
+    /**
+     * Locales whose percent format suffixes the symbol behind a space separator.
+     *
+     * @return the locales to test.
+     */
+    static Stream<Locale> suffixSymbolLocales() {
+        return Stream.of(Locale.FRANCE, Locale.GERMANY);
+    }
 
     @BeforeEach
     protected void setUp() {
@@ -106,18 +121,44 @@ class PercentValidatorTest {
     }
 
     /**
-     * Test percentage values with a pattern that suffixes the symbol, which locales such as fr-FR separate from the number with a non-breaking space. The
-     * symbol is optional, so its separator has to be optional too.
+     * Test percentage values against the JVM's own format for locales that suffix the symbol behind a space separator. The symbol is optional, so its separator
+     * has to be optional too. The pattern, separator and input are all derived from the locale data at run time, so the expectations hold on any JVM; on older
+     * JVMs whose locale data does not use a space separated suffix symbol the test is skipped.
+     */
+    @ParameterizedTest
+    @MethodSource("suffixSymbolLocales")
+    void testSuffixSymbolLocale(final Locale locale) {
+        final DecimalFormat format = (DecimalFormat) NumberFormat.getPercentInstance(locale);
+        final String pattern = format.toPattern();
+        final int symbolIndex = pattern.indexOf(PERCENT_SYMBOL);
+        assumeTrue(symbolIndex > 0 && Character.isSpaceChar(pattern.charAt(symbolIndex - 1)),
+                () -> locale + " does not use a space separated suffix symbol: " + pattern);
+        final char separator = pattern.charAt(symbolIndex - 1);
+        final char symbol = format.getDecimalFormatSymbols().getPercent();
+        final String withSymbol = format.format(0.12);
+        assumeTrue(withSymbol.endsWith(separator + Character.toString(symbol)), () -> locale + " does not format the symbol last: " + withSymbol);
+        final String noSymbol = withSymbol.substring(0, withSymbol.length() - 2);
+
+        final BigDecimalValidator instance = PercentValidator.getInstance();
+        final BigDecimal expected = new BigDecimal("0.12");
+        assertEquals(expected, instance.validate(withSymbol, locale), "symbol: " + locale);
+        assertEquals(expected, instance.validate(noSymbol, locale), "no symbol: " + locale);
+        assertNull(instance.validate(noSymbol + separator, locale), "separator without symbol: " + locale);
+    }
+
+    /**
+     * Test percentage values with an explicit pattern that suffixes the symbol behind a non-breaking space, so the expectations are pinned independently of the
+     * JVM's locale data. The symbol is optional, so its separator has to be optional too.
      */
     @Test
     void testSuffixSymbolPattern() {
-        final BigDecimalValidator validator = PercentValidator.getInstance();
+        final BigDecimalValidator instance = PercentValidator.getInstance();
         final String pattern = "#,##0" + NON_BREAKING_SPACE + PERCENT_SYMBOL;
         final BigDecimal expected = new BigDecimal("0.12");
 
-        assertEquals(expected, validator.validate("12" + NON_BREAKING_SPACE + PERCENT_SYMBOL, pattern, Locale.US), "symbol");
-        assertEquals(expected, validator.validate("12", pattern, Locale.US), "no symbol");
-        assertNull(validator.validate("12" + NON_BREAKING_SPACE, pattern, Locale.US), "separator without symbol");
+        assertEquals(expected, instance.validate("12" + NON_BREAKING_SPACE + PERCENT_SYMBOL, pattern, Locale.US), "symbol");
+        assertEquals(expected, instance.validate("12", pattern, Locale.US), "no symbol");
+        assertNull(instance.validate("12" + NON_BREAKING_SPACE, pattern, Locale.US), "separator without symbol");
     }
 
     /**

--- a/src/test/java/org/apache/commons/validator/routines/PercentValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/PercentValidatorTest.java
@@ -35,6 +35,11 @@ import org.junitpioneer.jupiter.DefaultLocale;
  */
 class PercentValidatorTest {
 
+    private static final char PERCENT_SYMBOL = '%';
+
+    /** The character locales such as fr-FR use between the number and a trailing percent symbol. */
+    private static final char NON_BREAKING_SPACE = '\u00A0';
+
     protected PercentValidator validator;
     private Locale originalLocale;
 
@@ -98,6 +103,21 @@ class PercentValidatorTest {
         assertTrue(instance.isInRange(value, BigInteger.ZERO, aboveLongMax));
         // A fractional bound is not floored: 5 >= 5.5 is false.
         assertFalse(instance.minValue(new BigDecimal("5"), new BigDecimal("5.5")));
+    }
+
+    /**
+     * Test percentage values with a pattern that suffixes the symbol, which locales such as fr-FR separate from the number with a non-breaking space. The
+     * symbol is optional, so its separator has to be optional too.
+     */
+    @Test
+    void testSuffixSymbolPattern() {
+        final BigDecimalValidator validator = PercentValidator.getInstance();
+        final String pattern = "#,##0" + NON_BREAKING_SPACE + PERCENT_SYMBOL;
+        final BigDecimal expected = new BigDecimal("0.12");
+
+        assertEquals(expected, validator.validate("12" + NON_BREAKING_SPACE + PERCENT_SYMBOL, pattern, Locale.US), "symbol");
+        assertEquals(expected, validator.validate("12", pattern, Locale.US), "no symbol");
+        assertNull(validator.validate("12" + NON_BREAKING_SPACE, pattern, Locale.US), "separator without symbol");
     }
 
     /**


### PR DESCRIPTION
Came at this from the other end: the German and French number validators were rejecting amounts the British one accepted, and the parse trace showed both the initial attempt and the lenient retry failing at the same index, which puts the fault in the fallback pattern rather than in the input.

1. `CurrencyValidator.parse` and `PercentValidator.parse` rebuild the pattern with the symbol removed and re-parse, but they delete only the symbol character itself.
2. `NumberFormat.getCurrencyInstance(Locale.GERMANY).toPattern()` is `#,##0.00 ¤` and `getPercentInstance(Locale.FRANCE).toPattern()` is `#,##0 %`, so what survives the rebuild is a mandatory non-breaking-space suffix.
3. The retry then fails exactly where the first parse did, so `validate("1.234,56", Locale.GERMANY)` and `validate("12", Locale.FRANCE)` come back null, while the prefix-symbol locales such as en-GB are fine.
4. The inverse is the worse half: a bare non-breaking space satisfies that leftover suffix on its own, so `validate("1.234,56 ", Locale.GERMANY)` yields 1234.56 and `validate("12 ", Locale.FRANCE)` yields 0.12 with no symbol present at all.

Both methods now drop the space adjacent to the symbol along with it. Left alone, the behaviour cuts both ways for every suffix-symbol locale (de, fr, it and the rest): correctly formatted amounts are silently refused, and a stray separator passes as a substitute for the currency or percent sign, which is a poor property in something callers lean on to reject malformed money. The two regression tests build an explicit suffix pattern instead of reading the JDK's locale data, so they will not drift with CLDR updates; both fail on master and pass with the change.

Thanks for your contribution to [Apache Commons](https://commons.apache.org/)! Your help is appreciated!

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
