### PR TITLE
Count unpaired carriage returns in adjustForLineEnding

### DIFF
--- a/src/main/java/org/apache/commons/validator/GenericValidator.java
+++ b/src/main/java/org/apache/commons/validator/GenericValidator.java
@@ -53,7 +53,10 @@ public class GenericValidator implements Serializable {
             }
         }
         final int rnCount = rCount + nCount;
-        return nCount * lineEndLength - rnCount;
+        // A carriage return that is not paired with a line feed is still a line ending, so the number of line
+        // endings is at least the number of carriage returns as well as the number of line feeds. Counting only
+        // the line feeds discounts every character of a CR-only value, leaving its adjusted length at zero.
+        return Math.max(nCount, rCount) * lineEndLength - rnCount;
     }
 
     /**

--- a/src/test/java/org/apache/commons/validator/GenericValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/GenericValidatorTest.java
@@ -40,24 +40,18 @@ class GenericValidatorTest {
      */
     @Test
     void testLengthUnpairedCarriageReturn() {
-
         // Use 0 for line end length
         assertTrue(GenericValidator.maxLength("12345\r", 5, 0), "Max=5 End=0");
-
         // Use 1 for line end length
         assertFalse(GenericValidator.maxLength("12345\r", 5, 1), "Max=5 End=1");
         assertTrue(GenericValidator.maxLength("12345\r", 6, 1), "Max=6 End=1");
-
         // Use 2 for line end length
         assertFalse(GenericValidator.maxLength("12345\r", 6, 2), "Max=6 End=2");
         assertTrue(GenericValidator.maxLength("12345\r", 7, 2), "Max=7 End=2");
-
         assertTrue(GenericValidator.minLength("12345\r", 7, 2), "Min=7 End=2");
         assertFalse(GenericValidator.minLength("12345\r", 8, 2), "Min=8 End=2");
-
         // Carriage returns alone used to leave the adjusted length at zero whatever the value's length
         assertFalse(GenericValidator.maxLength("\r\r\r\r\r", 1, 2), "Max=1 End=2");
-
         // The paired form is unchanged
         assertFalse(GenericValidator.maxLength("12345\r\n", 6, 2), "Max=6 End=2 paired");
         assertTrue(GenericValidator.maxLength("12345\r\n", 7, 2), "Max=7 End=2 paired");

--- a/src/test/java/org/apache/commons/validator/GenericValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/GenericValidatorTest.java
@@ -34,6 +34,35 @@ class GenericValidatorTest {
         assertFalse(GenericValidator.isDate("2/12/1999", "MM/dd/yyyy", true), "abbreviated month");
     }
 
+    /**
+     * A carriage return with no line feed next to it is a line ending in its own right, so it must not be
+     * discounted to zero characters.
+     */
+    @Test
+    void testLengthUnpairedCarriageReturn() {
+
+        // Use 0 for line end length
+        assertTrue(GenericValidator.maxLength("12345\r", 5, 0), "Max=5 End=0");
+
+        // Use 1 for line end length
+        assertFalse(GenericValidator.maxLength("12345\r", 5, 1), "Max=5 End=1");
+        assertTrue(GenericValidator.maxLength("12345\r", 6, 1), "Max=6 End=1");
+
+        // Use 2 for line end length
+        assertFalse(GenericValidator.maxLength("12345\r", 6, 2), "Max=6 End=2");
+        assertTrue(GenericValidator.maxLength("12345\r", 7, 2), "Max=7 End=2");
+
+        assertTrue(GenericValidator.minLength("12345\r", 7, 2), "Min=7 End=2");
+        assertFalse(GenericValidator.minLength("12345\r", 8, 2), "Min=8 End=2");
+
+        // Carriage returns alone used to leave the adjusted length at zero whatever the value's length
+        assertFalse(GenericValidator.maxLength("\r\r\r\r\r", 1, 2), "Max=1 End=2");
+
+        // The paired form is unchanged
+        assertFalse(GenericValidator.maxLength("12345\r\n", 6, 2), "Max=6 End=2 paired");
+        assertTrue(GenericValidator.maxLength("12345\r\n", 7, 2), "Max=7 End=2 paired");
+    }
+
     @Test
     void testMaxLength() {
 


### PR DESCRIPTION
`adjustForLineEnding` subtracts one character for every CR and every LF it counts, but adds `lineEndLength` back only once per LF, so it quietly assumes every carriage return arrives paired with a line feed. I went looking after noticing the two `lineEndLength` overloads have no coverage beyond the single `"12345\n\r"` fixture, and an unpaired CR turns out to contribute zero to the adjusted length: `maxLength("12345\r", 5, 1)` returns true where the adjusted length is 6, and `maxLength("\r\r\r\r\r", 1, 2)` returns true because a CR-only value adjusts to 0 no matter how long it is. A client picks its own line endings in a submitted textarea and nothing normalises them beforehand, so a field can be pushed past a declared maximum by an unbounded number of carriage returns; `minLength` mirrors it and wrongly rejects `minLength("12345\r", 7, 2)`, whose adjusted length is exactly 7.

Taking the line-ending count as the greater of the two counters rather than the LF count alone is enough, since the number of line endings is bounded below by the CR count and by the LF count. Keeping it in the private helper corrects both public overloads in one place rather than leaving each caller to normalise first, and the paired CRLF and LF-only forms compute exactly as they did, so the existing `testMaxLength` and `testMinLength` expectations are untouched. I have deliberately left the reversed `"\n\r"` sequence counting as one line ending, which is what those tests pin down today; the added regression covers the unpaired carriage return only and fails without the runtime change.

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
