### PR TITLE
Validate path, query and fragment for authority-less file URLs

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/UrlValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/UrlValidator.java
@@ -384,11 +384,12 @@ public class UrlValidator implements Serializable {
             return false;
         }
         final String authority = uri.getRawAuthority();
-        if ("file".equals(scheme) && GenericValidator.isBlankOrNull(authority)) { // Special case - file: allows an empty authority
-            return true; // this is a local file - nothing more to do here
-        }
+        // Special case - file: allows an empty authority, so only the authority check is skipped for it;
+        // the path, query and fragment below are validated as they are for any other scheme
+        final boolean emptyFileAuthority = "file".equals(scheme) && GenericValidator.isBlankOrNull(authority);
         // Validate the authority
-        if ("file".equals(scheme) && authority != null && authority.contains(":") || !isValidAuthority(authority)) {
+        if (!emptyFileAuthority
+                && ("file".equals(scheme) && authority != null && authority.contains(":") || !isValidAuthority(authority))) {
             return false;
         }
         if (!isValidPath(uri.getRawPath()) || !isValidQuery(uri.getRawQuery()) || !isValidFragment(uri.getRawFragment())) {

--- a/src/test/java/org/apache/commons/validator/routines/UrlValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/UrlValidatorTest.java
@@ -153,6 +153,45 @@ public class UrlValidatorTest {
     }
 
     @Test
+    void testFileSchemePath() {
+        final String[] schemes = { "file" };
+        final UrlValidator urlValidator = new UrlValidator(schemes, UrlValidator.ALLOW_LOCAL_URLS);
+
+        // an authority-less file: URL gets the same path check as one carrying an authority
+        assertFalse(urlValidator.isValid("file:///../../etc/passwd"));
+        assertFalse(urlValidator.isValid("file:/../../etc/passwd"));
+        assertFalse(urlValidator.isValid("file://localhost/../../etc/passwd"));
+
+        // percent-encoded form of the same, as covered for http in testValidator383
+        assertFalse(urlValidator.isValid("file:///..%2f..%2fetc/passwd"));
+        assertFalse(urlValidator.isValid("file:///%2e%2e/etc/passwd"));
+
+        // an opaque file: URI has no path at all, just as http:example.com has none
+        assertFalse(urlValidator.isValid("file:etc/passwd"));
+
+        assertTrue(urlValidator.isValid("file:///etc/hosts"));
+        assertTrue(urlValidator.isValid("file:/C:/path/to/dir/"));
+    }
+
+    @Test
+    void testFileSchemePathOptions() {
+        final String[] schemes = { "file" };
+
+        final UrlValidator noDoubleSlashes = new UrlValidator(schemes, UrlValidator.ALLOW_LOCAL_URLS);
+        assertFalse(noDoubleSlashes.isValid("file:///tmp/a//b"));
+        assertFalse(noDoubleSlashes.isValid("file://localhost/tmp/a//b"));
+
+        final UrlValidator allowDoubleSlashes = new UrlValidator(schemes, UrlValidator.ALLOW_LOCAL_URLS | UrlValidator.ALLOW_2_SLASHES);
+        assertTrue(allowDoubleSlashes.isValid("file:///tmp/a//b"));
+
+        final UrlValidator noFragments = new UrlValidator(schemes, UrlValidator.ALLOW_LOCAL_URLS | UrlValidator.NO_FRAGMENTS);
+        assertFalse(noFragments.isValid("file:///tmp/x#frag"));
+        assertFalse(noFragments.isValid("file://localhost/tmp/x#frag"));
+
+        assertTrue(noDoubleSlashes.isValid("file:///tmp/x#frag"));
+    }
+
+    @Test
     void testFragments() {
         final String[] schemes = { "http", "https" };
         UrlValidator urlValidator = new UrlValidator(schemes, UrlValidator.NO_FRAGMENTS);


### PR DESCRIPTION
`isValid` returns as soon as it sees a `file:` scheme with a blank authority, and that return sits above the line calling `isValidPath`, `isValidQuery` and `isValidFragment`. Every ordinary file URL has no authority, since `URI.getRawAuthority()` is null for `file:/x` and `file:///x` alike, so for a validator configured with the file scheme that whole stage is unreachable. I went looking after checking whether the percent-encoded traversal guard from VALIDATOR-383 held across schemes: `isValid("file:///../../etc/passwd")` and `isValid("file:///..%2f..%2fetc/passwd")` both come back true, while the byte-identical path written under an authority, `file://localhost/../../etc/passwd`, is correctly rejected. The option flags behave the same way, so `file:///tmp/a//b` passes with `ALLOW_2_SLASHES` off and `file:///tmp/x#frag` passes with `NO_FRAGMENTS` on.

The special case exists only to excuse a file URL from carrying an authority, so I have narrowed it to skip the authority check alone rather than to leave the method. Keeping the decision in `isValid` means every scheme reaches the same three per-part checks; moving containment out to callers would leave the hole open for anyone who configures the file scheme, and an application that normalises a validated `file:` URL into a filesystem path is exactly where that gets expensive. One deliberate behaviour change worth flagging: an opaque URI such as `file:etc/passwd` has a null raw path and is now rejected, which is what `http:example.com` already does. The existing file expectations in `testValidator276`, `testValidator391FAILS` and `testValidator391OK` are unchanged, and both added tests fail without the runtime change.

Before you push a pull request, review this list:

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body. Note that a maintainer may squash commits during the merge process.
