### PR TITLE
UrlValidator compare the file scheme case-insensitively in isValid

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/UrlValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/UrlValidator.java
@@ -384,12 +384,15 @@ public class UrlValidator implements Serializable {
             return false;
         }
         final String authority = uri.getRawAuthority();
+        // URI schemes are case-insensitive (RFC 3986 3.1) and isValidScheme already matches case-blind,
+        // so the file: handling has to recognise the scheme case-blind too
+        final boolean fileScheme = "file".equalsIgnoreCase(scheme);
         // Special case - file: allows an empty authority, so only the authority check is skipped for it;
         // the path, query and fragment below are validated as they are for any other scheme
-        final boolean emptyFileAuthority = "file".equals(scheme) && GenericValidator.isBlankOrNull(authority);
+        final boolean emptyFileAuthority = fileScheme && GenericValidator.isBlankOrNull(authority);
         // Validate the authority
         if (!emptyFileAuthority
-                && ("file".equals(scheme) && authority != null && authority.contains(":") || !isValidAuthority(authority))) {
+                && (fileScheme && authority != null && authority.contains(":") || !isValidAuthority(authority))) {
             return false;
         }
         if (!isValidPath(uri.getRawPath()) || !isValidQuery(uri.getRawQuery()) || !isValidFragment(uri.getRawFragment())) {

--- a/src/test/java/org/apache/commons/validator/routines/UrlValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/UrlValidatorTest.java
@@ -174,6 +174,22 @@ public class UrlValidatorTest {
     }
 
     @Test
+    void testFileSchemeCaseInsensitive() {
+        final String[] schemes = { "file" };
+        final UrlValidator urlValidator = new UrlValidator(schemes, UrlValidator.ALLOW_LOCAL_URLS);
+
+        // the scheme is case-insensitive, so an upper or mixed case file: URL is treated like the lower case form
+        assertTrue(urlValidator.isValid("file:///etc/hosts"));
+        assertTrue(urlValidator.isValid("FILE:///etc/hosts"));
+        assertTrue(urlValidator.isValid("File:///etc/hosts"));
+
+        // a Windows drive letter in the authority is never valid, whatever the scheme case, and must not
+        // slip past the guard the lower case form is checked against
+        assertFalse(urlValidator.isValid("file://C:/some.file"));
+        assertFalse(urlValidator.isValid("FILE://C:/some.file"));
+    }
+
+    @Test
     void testFileSchemePathOptions() {
         final String[] schemes = { "file" };
 


### PR DESCRIPTION
Chasing why an all upper case `FILE:` URL validated differently from its lower case twin led back to `isValid`. `isValidScheme` matches the scheme case-blind (it lower-cases before the allow-list check, and RFC 3986 3.1 makes schemes case-insensitive), but the file handling just below it tests `"file".equals(scheme)` twice, so a `FILE:` or `File:` scheme takes neither branch.

1. the empty-authority allowance is skipped, so a validator built for the file scheme rejects `FILE:///etc/hosts` while accepting `file:///etc/hosts`.
2. the drive-letter guard is skipped, so with `ALLOW_LOCAL_URLS` the authority `FILE://C:/some.file` is accepted although the byte-identical `file://C:/some.file` is rejected as it should be (`testValidator276` already pins the lower case form as never valid).

Computed the file-scheme test once with `equalsIgnoreCase` and reused it in both places. Left unfixed the second case is a validation bypass: an allow-list keyed on the scheme lets a crafted upper case authority slip past the guard the lower case form is stopped by. Added `testFileSchemeCaseInsensitive`, which fails on master and passes with the change.

- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [ ] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [ ] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute?
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied. This may not always be possible, but it is a best practice.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.
