### PR TITLE
Reject invalid ISBN-10 in convertToISBN13

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/ISBNValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/ISBNValidator.java
@@ -179,6 +179,9 @@ public class ISBNValidator implements Serializable {
         if (input.length() != ISBN_10_LEN) {
             throw new IllegalArgumentException("Invalid length " + input.length() + " for '" + input + "'");
         }
+        if (!isbn10Validator.isValid(input)) {
+            return null;
+        }
 
         // Calculate the new ISBN-13 code (drop the original checkdigit)
         String isbn13 = "978" + input.substring(0, ISBN_10_LEN - 1);

--- a/src/test/java/org/apache/commons/validator/routines/ISBNValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/ISBNValidatorTest.java
@@ -96,8 +96,20 @@ class ISBNValidatorTest {
         final String input3 = "";
         assertThrows(IllegalArgumentException.class, () -> validator.convertToISBN13(input3), "Expected IllegalArgumentException for '" + input3 + "'");
 
-        final String input4 = "X234567890";
+        final String input4 = "1234567890X";
         assertThrows(IllegalArgumentException.class, () -> validator.convertToISBN13(input4), "Expected IllegalArgumentException for '" + input4 + "'");
+    }
+
+    /**
+     * Test method for {@link org.apache.commons.validator.routines.ISBNValidator#convertToISBN13(java.lang.String)}.
+     */
+    @Test
+    void testConvertToISBN13Invalid() {
+        final ISBNValidator validator = ISBNValidator.getInstance();
+        // Correct length, but not a valid ISBN-10.
+        assertNull(validator.convertToISBN13("1234567890"), "wrong check digit");
+        assertNull(validator.convertToISBN13("020163385Y"), "invalid check character");
+        assertNull(validator.convertToISBN13("X234567890"), "non-digit body");
     }
 
     /**


### PR DESCRIPTION
convertToISBN13 says in its Javadoc that it returns null when the ISBN-10 is not valid, but tracing the method shows it only rejects a null argument and a length other than ten, then builds the ISBN-13 from the first nine characters and appends a freshly calculated EAN-13 check digit. The ISBN-10 check digit itself is never verified, so a well-formed ten-digit code with the wrong check digit slips straight through: convertToISBN13("1234567890") returns "9781234567897", and isValidISBN13 then reports that manufactured code as valid. The root cause is a missing validity check, not the length guard, which already behaves as documented.

The sibling ISSNValidator.convertToEAN13 handles this correctly by calling validate() first and returning null on failure, so I mirrored that here: after the length check convertToISBN13 now returns null when isbn10Validator.isValid rejects the input. The guard belongs in the converter because the public method owns the null-for-invalid contract, and the internal validate() path is unchanged since it only ever passes codes it has already validated. Left as is, the method quietly turns an invalid ISBN-10 into a plausible ISBN-13, which is exactly the sort of bad data a validator is meant to stop.