### PR TITLE
Reject under-length codes in SedolCheckDigit

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/checkdigit/SedolCheckDigit.java
+++ b/src/main/java/org/apache/commons/validator/routines/checkdigit/SedolCheckDigit.java
@@ -66,8 +66,13 @@ public final class SedolCheckDigit extends ModulusCheckDigit {
      */
     @Override
     protected int calculateModulus(final String code, final boolean includesCheckDigit) throws CheckDigitException {
-        if (code.length() > POSITION_WEIGHT.length) {
-            throw new CheckDigitException("Invalid Code Length = %d", code.length());
+        final int length = code.length();
+        // A SEDOL is exactly seven characters. When the check digit is included the whole code must be that
+        // length; the previous test only rejected over-length codes, so a shorter string carrying a chance
+        // modulus 10 check digit (for example "55") still validated. The calculate path receives the six
+        // character base, so only the over-length case is guarded there.
+        if (length > POSITION_WEIGHT.length || includesCheckDigit && length != POSITION_WEIGHT.length) {
+            throw new CheckDigitException("Invalid Code Length = %d", length);
         }
         return super.calculateModulus(code, includesCheckDigit);
     }

--- a/src/test/java/org/apache/commons/validator/routines/checkdigit/SedolCheckDigitTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/checkdigit/SedolCheckDigitTest.java
@@ -64,4 +64,15 @@ class SedolCheckDigitTest extends AbstractCheckDigitTest {
         assertFalse(routine.isValid(code), "Should fail (contains a vowel): " + code);
     }
 
+    /**
+     * A SEDOL is exactly seven characters, but a shorter string can carry a modulus 10 check digit by chance (for
+     * example "55", "550" and "5500" all weight to 20, and "0055" to 40), so the length must be enforced or isValid
+     * accepts it.
+     */
+    @ParameterizedTest
+    @ValueSource(strings = { "55", "550", "5500", "0055" })
+    void testUnderLengthRejected(final String code) {
+        assertFalse(routine.isValid(code), "Should fail (not seven characters): " + code);
+    }
+
 }


### PR DESCRIPTION
`SedolCheckDigit.SEDOL_CHECK_DIGIT.isValid` is a public `CheckDigit` entry point with no wrapping validator, yet its `calculateModulus` override only rejects codes longer than the seven-character weight table. A shorter string whose weighted digits happen to sum to a multiple of ten therefore validates: `isValid("55")`, `isValid("550")`, `isValid("5500")` and `isValid("0055")` all return true, though a SEDOL is defined as exactly seven characters. I traced it back from the weight loop after noticing the base-class `isValid` does no length check of its own, so this one-sided `>` comparison is the only thing standing between a short input and a false positive.

The guard now also requires the validated form (the code passed with its check digit) to be exactly seven characters, while the calculate path still receives the six-character base and so keeps only the over-length check. Holding the length rule inside `calculateModulus`, next to the weight table it depends on, keeps the validate and calculate callers consistent without either repeating it. Left as it was, a caller relying on `SEDOL_CHECK_DIGIT` to screen out malformed identifiers would accept a two-character string as a valid security identifier.
