### PR TITLE
reject zone ids and prefix lengths in IPv6 email literals

### DIFF
--- a/src/main/java/org/apache/commons/validator/routines/EmailValidator.java
+++ b/src/main/java/org/apache/commons/validator/routines/EmailValidator.java
@@ -44,9 +44,11 @@ public class EmailValidator implements Serializable {
     private static final String EMAIL_REGEX = "^(.+)@(\\S+)$";
 
     /**
-     * RFC 5321 section 4.1.3: an IPv6 address literal carries the "IPv6:" tag (case-insensitive), an IPv4 literal is untagged.
+     * RFC 5321 section 4.1.3: an IPv6 address literal carries the "IPv6:" tag (case-insensitive), an IPv4 literal is untagged. The address itself is
+     * built from hex digits, ':' and the embedded IPv4 dotted form only, so a zone id ('%') or prefix length ('/'), which
+     * {@link InetAddressValidator#isValidInet6Address(String)} tolerates, is kept out of the literal here.
      */
-    private static final String IP_DOMAIN_REGEX = "^\\[((?i)IPv6:)?(.*)\\]$";
+    private static final String IP_DOMAIN_REGEX = "^\\[((?i)IPv6:)?([0-9a-fA-F:.]+)\\]$";
     private static final String USER_REGEX = "^" + WORD + "(\\." + WORD + ")*$";
 
     private static final Pattern EMAIL_PATTERN = Pattern.compile(EMAIL_REGEX);

--- a/src/test/java/org/apache/commons/validator/routines/EmailValidatorTest.java
+++ b/src/test/java/org/apache/commons/validator/routines/EmailValidatorTest.java
@@ -462,6 +462,24 @@ public class EmailValidatorTest {
     }
 
     /**
+     * Tests that an IPv6 address literal carrying a zone (scope) id or a prefix length is rejected. RFC 5321 section 4.1.3 builds IPv6-addr from
+     * hex groups and an optional embedded IPv4 address only, so neither belongs in a mailbox address literal even though
+     * {@link InetAddressValidator#isValidInet6Address(String)} accepts both.
+     */
+    @Test
+    void testEmailWithIpv6AddressLiteralZoneOrPrefix() {
+        assertFalse(validator.isValid("someone@[IPv6:fe80::1%eth0]"));
+        assertFalse(validator.isValid("someone@[IPv6:fe80::1%25eth0]"));
+        assertFalse(validator.isValid("someone@[IPv6:2001:db8::1/64]"));
+        assertFalse(validator.isValid("someone@[IPv6:::1/128]"));
+        assertFalse(validator.isValid("someone@[216.109.118.76/24]"));
+        // The bare address forms, including the embedded IPv4 form, still validate.
+        assertTrue(validator.isValid("someone@[IPv6:fe80::1]"));
+        assertTrue(validator.isValid("someone@[IPv6:2001:db8::1]"));
+        assertTrue(validator.isValid("someone@[IPv6:::ffff:216.109.118.76]"));
+    }
+
+    /**
      * Tests the email validation with numeric domains.
      */
     @Test


### PR DESCRIPTION
- [x] Read the [contribution guidelines](CONTRIBUTING.md) for this project.
- [x] Read the [ASF Generative Tooling Guidance](https://www.apache.org/legal/generative-tooling.html) if you use Artificial Intelligence (AI).
- [x] I used AI to create any part of, or all of, this pull request. Which AI tool was used to create this pull request, and to what extent did it contribute? Claude Code (Anthropic) helped investigate the behaviour and draft the change and the test; I reviewed, ran and verified all of it before submitting.
- [x] Run a successful build using the default [Maven](https://maven.apache.org/) goal with `mvn`; that's `mvn` on the command line by itself.
- [x] Write unit tests that match behavioral changes, where the tests fail if the changes to the runtime are not applied.
- [x] Write a pull request description that is detailed enough to understand what the pull request does, how, and why.
- [x] Each commit in the pull request should have a meaningful subject line and body.

`EmailValidator.isValidDomain` matches a bracketed host with `IP_DOMAIN_REGEX`, whose address group is `(.*)`, and passes a tagged literal straight to `InetAddressValidator.isValidInet6Address`. That validator is general purpose and deliberately strips a trailing zone id (`%eth0`) and a CIDR prefix length (`/64`) before checking the address, so `isValid("user@[IPv6:fe80::1%eth0]")`, `isValid("user@[IPv6:2001:db8::1/64]")` and `isValid("user@[IPv6:::1/128]")` all return true. I noticed it while tracing the `IPv6:` tag handling from #428 through to the address check: RFC 5321 section 4.1.3 builds `IPv6-addr` from hex groups, `:` and the embedded IPv4 dotted form only, with no zone or prefix production, so none of those literals can name a mailbox host. Left as it is, an address that passes validation can carry a literal that a conformant SMTP parser refuses outright. The IPv4 branch is unaffected because `isValidInet4Address` is a strict regex.

The fix stays in the regex, as asked on #428: the address group becomes `[0-9a-fA-F:.]+`, the same class `UrlValidator` already uses for a bracketed IPv6 host, so a literal carrying `%` or `/` no longer matches the address-literal pattern and drops through to the symbolic-domain check, which rejects it. The tagged forms, including the embedded IPv4 form, parse exactly as before, and `InetAddressValidator` keeps its zone and prefix support for callers that want it. The regression test fails on master at its first assertion and passes with the change; the full default Maven goal with `-Ddoclint=all` is green (3300 tests, checkstyle, PMD, SpotBugs and japicmp clean).
